### PR TITLE
make install for linux

### DIFF
--- a/Grabber.pro
+++ b/Grabber.pro
@@ -15,7 +15,7 @@ unix:!macx{
 	config.extra = touch /usr/local/Grabber/example/settings.ini
 	desktop.path = /usr/share/applications/Grabber
 	desktop.files += release/Grabber.desktop
-	icon.path = /usr/share/icons/hicolor/128x128/apps
+	icon.path = /usr/share/icons/128x128/apps
 	icon.extra = cp icon.png Grabber.png
 	icon.files += Grabber.png
 	INSTALLS += target desktop icon config

--- a/Grabber.pro
+++ b/Grabber.pro
@@ -6,3 +6,17 @@ SUBDIRS = gui
 win32 {
     SUBDIRS += cli
 }
+
+unix:!macx{
+	target.path = /usr/local/bin
+	target.files += gui/Grabber
+	config.path = /usr/local/Grabber/example
+	config.files = release/languages release/sites release/words.txt
+	config.extra = touch /usr/local/Grabber/example/settings.ini
+	desktop.path = /usr/share/applications/Grabber
+	desktop.files += release/Grabber.desktop
+	icon.path = /usr/share/icons/hicolor/128x128/apps
+	icon.extra = cp icon.png Grabber.png
+	icon.files += Grabber.png
+	INSTALLS += target desktop icon config
+}

--- a/release/Grabber.desktop
+++ b/release/Grabber.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=Grabber
+Exec=Grabber
+Icon=Grabber
+Type=Application
+Categories=Network;

--- a/source/functions.cpp
+++ b/source/functions.cpp
@@ -395,6 +395,10 @@ QString savePath(QString file, bool exists)
 	{ return QDir::toNativeSeparators(QDir::currentPath()+"/"+file); }
 	if (QFile(QDir::toNativeSeparators(QDir::homePath()+"/Grabber/"+check)).exists())
 	{ return QDir::toNativeSeparators(QDir::homePath()+"/Grabber/"+file); }
+	#ifdef __linux__
+	if (QFile(QDir::toNativeSeparators(QDir::homePath()+"/.Grabber/"+check)).exists())
+	{ return QDir::toNativeSeparators(QDir::homePath()+"/.Grabber/"+file); }
+	#endif
 	return QDir::toNativeSeparators(QStandardPaths::writableLocation(QStandardPaths::DataLocation)+"/"+file);
 }
 


### PR DESCRIPTION
This commit sets up ```make install``` for linux and copies the default configs to /usr/local/Grabber/example where the user can ```cp /usr/local/Grabber/example/* ~/.Grabber/``` to get grabber running without all the files being in one directory. It also makes Grabber search for the ~/.Grabber directory Included is a Grabber.desktop file for linux desktop environments that support them.