### PR TITLE
Fix #566

### DIFF
--- a/source/textedit.cpp
+++ b/source/textedit.cpp
@@ -51,7 +51,6 @@ void TextEdit::wheelEvent(QWheelEvent *e)
 void TextEdit::doColor()
 {
 	QString txt = " "+this->toPlainText().toHtmlEscaped()+" ";
-
     // Color favorited tags
 	for (int i = 0; i < m_favorites.size(); i++)
         txt.replace(" "+m_favorites.at(i)+" ", " <span style=\"color:#ffc0cb\">"+m_favorites.at(i)+"</span> ");
@@ -85,10 +84,20 @@ void TextEdit::doColor()
     // Setup cursor
 	QTextCursor crsr = textCursor();
 	pos = crsr.columnNumber();
-	int lengh = crsr.selectionEnd()-crsr.selectionStart();
+	int start = crsr.selectionStart();
+	int end = crsr.selectionEnd();
 	setHtml(txt.mid(1, txt.length()-2));
-	crsr.setPosition(pos-lengh, QTextCursor::MoveAnchor);
-	crsr.setPosition(pos, QTextCursor::KeepAnchor);
+	//If the cursor is at the right side of (if any) selected text
+	if (pos == end)
+	{
+		crsr.setPosition(start, QTextCursor::MoveAnchor);
+		crsr.setPosition(end, QTextCursor::KeepAnchor);
+	}
+	else
+	{
+		crsr.setPosition(end, QTextCursor::MoveAnchor);
+		crsr.setPosition(start, QTextCursor::KeepAnchor);
+	}
 	setTextCursor(crsr);
 }
 
@@ -182,7 +191,6 @@ void TextEdit::keyPressEvent(QKeyEvent *e)
 				return;
 		}
 	}
-
 	bool isShortcut = ((e->modifiers() & Qt::ControlModifier) && e->key() == Qt::Key_Space); // CTRL+Space
 	if (!c || !isShortcut) // do not process the shortcut when we have a completer
 	{
@@ -194,21 +202,17 @@ void TextEdit::keyPressEvent(QKeyEvent *e)
 		QTextEdit::keyPressEvent(e);
 	}
 	doColor();
-
 	const bool ctrlOrShift = e->modifiers() & (Qt::ControlModifier | Qt::ShiftModifier);
 	if (!c || (ctrlOrShift && e->text().isEmpty()))
         return;
-
 	static QString eow(" ");
 	bool hasModifier = (e->modifiers() != Qt::NoModifier) && !ctrlOrShift;
 	QString completionPrefix = textUnderCursor();
-
 	if (!isShortcut && (hasModifier || e->text().isEmpty()|| completionPrefix.length() < 3 || eow.contains(e->text().right(1))))
 	{
 		c->popup()->hide();
 		return;
 	}
-
 	if (completionPrefix != c->completionPrefix())
         c->setCompletionPrefix(completionPrefix);
 

--- a/source/textedit.cpp
+++ b/source/textedit.cpp
@@ -51,6 +51,7 @@ void TextEdit::wheelEvent(QWheelEvent *e)
 void TextEdit::doColor()
 {
 	QString txt = " "+this->toPlainText().toHtmlEscaped()+" ";
+    
     // Color favorited tags
 	for (int i = 0; i < m_favorites.size(); i++)
         txt.replace(" "+m_favorites.at(i)+" ", " <span style=\"color:#ffc0cb\">"+m_favorites.at(i)+"</span> ");
@@ -191,6 +192,7 @@ void TextEdit::keyPressEvent(QKeyEvent *e)
 				return;
 		}
 	}
+
 	bool isShortcut = ((e->modifiers() & Qt::ControlModifier) && e->key() == Qt::Key_Space); // CTRL+Space
 	if (!c || !isShortcut) // do not process the shortcut when we have a completer
 	{
@@ -202,17 +204,21 @@ void TextEdit::keyPressEvent(QKeyEvent *e)
 		QTextEdit::keyPressEvent(e);
 	}
 	doColor();
+	
 	const bool ctrlOrShift = e->modifiers() & (Qt::ControlModifier | Qt::ShiftModifier);
 	if (!c || (ctrlOrShift && e->text().isEmpty()))
         return;
+	
 	static QString eow(" ");
 	bool hasModifier = (e->modifiers() != Qt::NoModifier) && !ctrlOrShift;
 	QString completionPrefix = textUnderCursor();
+	
 	if (!isShortcut && (hasModifier || e->text().isEmpty()|| completionPrefix.length() < 3 || eow.contains(e->text().right(1))))
 	{
 		c->popup()->hide();
 		return;
 	}
+	
 	if (completionPrefix != c->completionPrefix())
         c->setCompletionPrefix(completionPrefix);
 


### PR DESCRIPTION
The problems with Left + Shift, Left + Ctrl + Shift, and Left + Home were caused by the lines 86-91 in doColor().


```cpp
QTextCursor crsr = textCursor();
pos = crsr.columnNumber();
int lengh = crsr.selectionEnd()-crsr.selectionStart();
setHtml(txt.mid(1, txt.length()-2));
crsr.setPosition(pos-lengh, QTextCursor::MoveAnchor);
crsr.setPosition(pos, QTextCursor::KeepAnchor);
```

The selectionEnd and selectionStart values of the cursor were being incorrectly set when the cursor was at the right end of highlighted text.  Here is a worked out example of how it goes wrong:

aaa|

When the user presses Shift + Left and the rightmost "a" is selected and right before doColor() is called, selectionStart = 2, selectionEnd = 3, and position = 2 for the cursor.
doColor is supposed only change the text, but what happens is
selectionStart = pos - length = 2 - 1 = 1, selectionEnd = 2, and position = 1 for the cursor, resulting in the wrong text being selected.

I have tested my solution against all the text shortcuts of I know of.