### PR TITLE
Linux installation prefix support

### DIFF
--- a/Grabber.pro
+++ b/Grabber.pro
@@ -8,15 +8,17 @@ win32 {
 }
 
 unix:!macx{
-	target.path = /usr/local/bin
-	target.files += gui/Grabber
-	config.path = /usr/local/Grabber/example
-	config.files = release/languages release/sites release/words.txt
-	config.extra = touch /usr/local/Grabber/example/settings.ini
-	desktop.path = /usr/share/applications/Grabber
+	isEmpty(PREFIX){
+		PREFIX = /usr/local
+	}
+	config.path = $$PREFIX/share/Grabber/example
+	config.extra = touch release/settings.ini
+	config.files = release/languages release/sites release/words.txt release/settings.ini
+
+	desktop.path = $$PREFIX/share/applications/Grabber
 	desktop.files += release/Grabber.desktop
-	icon.path = /usr/share/icons/128x128/apps
+	icon.path = $$PREFIX/share/icons/128x128/apps
 	icon.extra = cp icon.png Grabber.png
 	icon.files += Grabber.png
-	INSTALLS += target desktop icon config
+	INSTALLS += desktop icon config
 }

--- a/gui/gui.pro
+++ b/gui/gui.pro
@@ -43,3 +43,12 @@ SOURCES += $${PDIR}/source/*.cpp \
     $${PDIR}/source/rename-existing/*.cpp
 FORMS += $${PDIR}/ui/*.ui \
     ../source/rename-existing/*.ui
+
+#linux install script
+unix:!macx{
+	isEmpty(PREFIX){
+		PREFIX = /usr/local
+	}
+	target.path = $$PREFIX/bin
+	INSTALLS += target
+}


### PR DESCRIPTION
used by setting the environment variable PREFIX when calling qmake Grabber.pro e.g.
```
$ qmake  PREFIX=/usr Grabber.pro
```
If PREFIX is not set it defaults to /usr/local

This can help automate creating distribution packages. I also plan on creating an aur package for Arch Linux, this should enable that.