### PR TITLE
Update build-mac.sh

### DIFF
--- a/build-mac.sh
+++ b/build-mac.sh
@@ -6,9 +6,6 @@ brew install gcc
 qmake Grabber.pro
 make
 mv gui/Grabber.app release
-mv release/languages $appDir/
-mv release/sites $appDir/
-mv release/words.txt $appDir/
-mv release/CDR.exe $appDir/
+mv release/* $appDir
 touch $appDir/settings.ini
 echo "Grabber has been compiled in the release directory. To run it, type 'open ./release/Grabber.app'"


### PR DESCRIPTION
Used a * to give the build script more flexibility when determining which files belong in the folder with the executable.