### PR TITLE
Fix batches saving before their tags load ( Bionus/imgbrd-grabber#608 )

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1352,6 +1352,28 @@ void mainWindow::getAllImages()
 		if (fn.needExactTags(forceImageUrl))
 			m_must_get_tags = true;
 	}
+    if (m_settings->value("Textfile/activate", false).toBool())
+    {
+        Filename fn(m_settings->value("Textfile/content", "").toString());
+        if (fn.needExactTags())
+            m_must_get_tags = true;
+    }
+    QList<QString> settings;
+    settings
+        << "Exec/tag_before"
+        << "Exec/image"
+        << "Exec/tag_after"
+        << "Exec/SQL/before"
+        << "Exec/SQL/tag_before"
+        << "Exec/SQL/image"
+        << "Exec/SQL/tag_after"
+        << "Exec/SQL/after";
+    for (int s = 0; s < settings.size() && !m_must_get_tags; s++)
+    {
+        Filename fn(m_settings->value(settings[s], "").toString());
+        if (fn.needExactTags())
+            m_must_get_tags = true;
+    }
 	if (m_must_get_tags)
 		log("Downloading images details.");
 	else


### PR DESCRIPTION
This at least solves the issue, needExactTags should be moved out of filename and into another class due to it not being filename specific. needExactTags may also need to be modified to ensure that we are returning true on any possible situation that we may need to get all of the tags.