### PR TITLE
Fix linux install script

### DIFF
--- a/Grabber.pri
+++ b/Grabber.pri
@@ -17,12 +17,12 @@ UI_DIR      = $$DESTDIR/ui
 
 # Global
 APP_VERSION = \\\"5.2.2\\\"
-PREFIX = \\\"$$(PREFIX)\\\"
+APP_PREFIX = \\\"$$(PREFIX)\\\"
 
 # General
 TEMPLATE = app
 DEFINES += VERSION=$$APP_VERSION
-DEFINES += PREFIX=$$PREFIX
+DEFINES += PREFIX=$$APP_PREFIX
 QT += core network xml sql script
 
 # Additionnal

--- a/Grabber.pro
+++ b/Grabber.pro
@@ -33,8 +33,7 @@ unix:!macx{
 	desktop.files += release/Grabber.desktop
 
 	icon.path = $$PREFIX/share/pixmaps
-	icon.extra = cp resources/icon.png resources/Grabber.png
-	icon.files += resources/Grabber.png
+	icon.extra = install -D -m644 resources/icon.png $(INSTALL_ROOT)/$$PREFIX/share/pixmaps/Grabber.png
 
 	INSTALLS += desktop icon config languages
 }

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -15,6 +15,8 @@ CONFIG  += console testcase
 CONFIG  -= app_bundle
 TEMPLATE = app
 DEFINES += TEST=1
+target.files = 
+INSTALLS += target
 
 # Code coverage
 @


### PR DESCRIPTION
Commit 72624d49d3ddd5c9c1e05722d04c7e3f6f575daa broke the linux install scripts as it overwrote  the `PREFIX` variable that was passed to subprojects (`gui`, `tests`) with `PREFIX=\\\"$$(PREFIX)\\\"` which isn't a very valid path. This also fixes the problem of the icon not being copied to the `pixmaps` folder, as well as tests being installed.