### PR TITLE
Fix prefix when looking for Grabber files on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(USE_SSL 1)
 add_definitions(-DVERSION="5.4.2")
 add_definitions(-DPROJECT_WEBSITE_URL="https://bionus.github.io/imgbrd-grabber/")
 add_definitions(-DPROJECT_GITHUB_URL="https://github.com/Bionus/imgbrd-grabber")
-add_definitions(-DPREFIX="$ENV{PREFIX}")
+add_definitions(-DPREFIX="${CMAKE_INSTALL_PREFIX}")
 
 # SSL
 if(USE_SSL)


### PR DESCRIPTION
Currently this will always use `/usr/local` so Grabber will not find sources when installed with a different prefix. Using this method when `-DCMAKE_INSTALL_PREFIX` is set it will use that prefix or the default from `CMAKE_INSTALL_PREFIX` (`/usr/local` on Linux and `C:\Program Files` on Windows)