### PR TITLE
Prefer home folder over system folder settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(USE_SSL 1)
 add_definitions(-DVERSION="5.4.2")
 add_definitions(-DPROJECT_WEBSITE_URL="https://bionus.github.io/imgbrd-grabber/")
 add_definitions(-DPROJECT_GITHUB_URL="https://github.com/Bionus/imgbrd-grabber")
-add_definitions(-DPREFIX="$ENV{PREFIX}")
+add_definitions(-DPREFIX="${CMAKE_INSTALL_PREFIX}")
 
 # SSL
 if(USE_SSL)

--- a/lib/src/functions.cpp
+++ b/lib/src/functions.cpp
@@ -216,10 +216,10 @@ QString savePath(QString file, bool exists)
 	if (QFile(QDir::toNativeSeparators(QDir::homePath()+"/Grabber/"+check)).exists())
 	{ return QDir::toNativeSeparators(QDir::homePath()+"/Grabber/"+file); }
 	#ifdef __linux__
-		if (QFile(QDir::toNativeSeparators(QString(PREFIX)+"/share/Grabber/"+check)).exists())
-		{ return QDir::toNativeSeparators(QString(PREFIX)+"/share/Grabber/"+file); }
 		if (QFile(QDir::toNativeSeparators(QDir::homePath()+"/.Grabber/"+check)).exists())
 		{ return QDir::toNativeSeparators(QDir::homePath()+"/.Grabber/"+file); }
+		if (QFile(QDir::toNativeSeparators(QString(PREFIX)+"/share/Grabber/"+check)).exists())
+		{ return QDir::toNativeSeparators(QString(PREFIX)+"/share/Grabber/"+file); }
 	#endif
 	return QDir::toNativeSeparators(QStandardPaths::writableLocation(QStandardPaths::DataLocation)+"/"+file);
 }


### PR DESCRIPTION
Currently Grabber will check for the system settings file and folders which are only writable by root, this pull request changes Grabber to prefer settings files in the user's home directory if they exist so that changes may be saved.