### PR TITLE
Fix gcc compile errors on MAC OS and Debian 9

### DIFF
--- a/tests/src/models/filename-test.cpp
+++ b/tests/src/models/filename-test.cpp
@@ -670,11 +670,11 @@ void FilenameTest::testNeedTemporaryFile()
 
 void FilenameTest::testNeedExactTags()
 {
-	QCOMPARE(Filename("%md5%.%ext%").needExactTags(false), 0);
+	QCOMPARE(Filename("%md5%.%ext%").needExactTags(NULL), 0);
 	QCOMPARE(Filename("%md5%.%ext%").needExactTags(m_site), 0);
-	QCOMPARE(Filename("javascript:md5 + '.' + ext").needExactTags(false), 2);
-	QCOMPARE(Filename("%character% %md5%.%ext%").needExactTags(false), 1);
-	QCOMPARE(Filename("%all:includenamespace% %md5%.%ext%").needExactTags(false), 1);
+	QCOMPARE(Filename("javascript:md5 + '.' + ext").needExactTags(NULL), 2);
+	QCOMPARE(Filename("%character% %md5%.%ext%").needExactTags(NULL), 1);
+	QCOMPARE(Filename("%all:includenamespace% %md5%.%ext%").needExactTags(NULL), 1);
 
 	Filename filename("%filename%.%ext%");
 	QCOMPARE(filename.needExactTags(), 0);


### PR DESCRIPTION
Compiling fails with gcc on MAC OS 10.13.5, Fedora 28 and Debian 9
Builds now successful on Debian 9 and MAC OS. 
Fedora 28 is waiting to be confirmed
rel Issue:
https://github.com/Bionus/imgbrd-grabber/issues/1316