### PR TITLE
Add features to the cli

### DIFF
--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -3,7 +3,8 @@ project(cli)
 add_definitions(-DCLI=1)
 
 find_package(Qt5Core REQUIRED)
-set(QT_LIBRARIES Qt5::Core)
+find_package(Qt5Network REQUIRED)
+set(QT_LIBRARIES Qt5::Core Qt5::Network)
 
 file(GLOB_RECURSE SOURCES "src/*.cpp")
 include_directories("src/" "../lib/src/" "..")

--- a/cli/src/main.cpp
+++ b/cli/src/main.cpp
@@ -37,6 +37,7 @@ int main(int argc, char *argv[])
 	const QCommandLineOption verboseOption(QStringList() << "d" << "debug", "Show debug messages.");
 	const QCommandLineOption tagsMinOption(QStringList() << "tm" << "tags-min", "Minimum count for tags to be returned.", "count", "0");
 	const QCommandLineOption tagsFormatOption(QStringList() << "tf" << "tags-format", "Format for returning tags.", "format", "%tag\t%count\t%type");
+	const QCommandLineOption ignoreErrorOption(QStringList() << "ignore-error", "don't exit on error.");
 	parser.addOption(tagsOption);
 	parser.addOption(sourceOption);
 	parser.addOption(pageOption);
@@ -52,6 +53,7 @@ int main(int argc, char *argv[])
 	parser.addOption(tagsFormatOption);
 	parser.addOption(noDuplicatesOption);
 	parser.addOption(verboseOption);
+	parser.addOption(ignoreErrorOption);
 	const QCommandLineOption returnCountOption(QStringList() << "rc" << "return-count", "Return total image count.");
 	const QCommandLineOption returnTagsOption(QStringList() << "rt" << "return-tags", "Return tags for a search.");
 	const QCommandLineOption returnPureTagsOption(QStringList() << "rp" << "return-pure-tags", "Return tags.");
@@ -65,9 +67,15 @@ int main(int argc, char *argv[])
 
 	parser.process(app);
 
-	#ifndef QT_DEBUG
-		Logger::setupMessageOutput(parser.isSet(verboseOption));
-	#endif
+	if (parser.isSet(verboseOption)) {
+        #ifndef QT_DEBUG
+		    Logger::getInstance().logToConsole();
+        #endif
+		Logger::getInstance().setLogLevel(Logger::Debug);
+	}
+
+	if (!parser.isSet(ignoreErrorOption))
+		Logger::getInstance().setExitOnError(true);
 
 	Profile *profile = new Profile(savePath());
 	profile->purgeTemp(24 * 60 * 60);

--- a/lib/src/logger.cpp
+++ b/lib/src/logger.cpp
@@ -6,6 +6,12 @@
 	#include <QDebug>
 #endif
 
+void Logger::logToConsole()
+{
+	if (m_logFile.isOpen()) m_logFile.close();
+	m_logFile.open(stdout, QIODevice::WriteOnly);
+}
+
 
 void Logger::setLogFile(const QString &path)
 {
@@ -21,6 +27,11 @@ QString Logger::logFile() const
 void Logger::setLogLevel(LogLevel level)
 {
 	m_level = level;
+}
+
+void Logger::setExitOnError(bool val)
+{
+	m_exitOnError = val;
 }
 
 
@@ -67,6 +78,9 @@ void Logger::setupMessageOutput(bool log)
  */
 void Logger::log(const QString &l, LogLevel level)
 {
+	if (m_exitOnError && level == Logger::LogLevel::Error)
+		throw std::runtime_error(l.toStdString());
+
 	if (level < m_level)
 		return;
 

--- a/lib/src/logger.h
+++ b/lib/src/logger.h
@@ -36,12 +36,14 @@ class Logger : public QObject
 		static void noMessageOutput(QtMsgType type, const QMessageLogContext &context, const QString &message);
 		static void setupMessageOutput(bool log);
 
+		void setExitOnError(bool val);
 		void setLogFile(const QString &path);
 		void setLogLevel(LogLevel level);
 		void log(const QString &, LogLevel level = Info);
 		void logCommand(const QString &);
 		void logCommandSql(const QString &);
 		void logUpdate(const QString &);
+		void logToConsole();
 
 		QString logFile() const;
 
@@ -52,6 +54,7 @@ class Logger : public QObject
 		Logger() = default;
 		QFile m_logFile, m_fCommandsLog, m_fCommandsSqlLog;
 		LogLevel m_level = LogLevel::Info;
+		bool m_exitOnError = false;
 };
 
 

--- a/lib/src/models/image.cpp
+++ b/lib/src/models/image.cpp
@@ -343,9 +343,11 @@ void Image::parseDetails()
 {
 	m_loadingDetails = false;
 
-	// Aborted
-	if (m_loadDetails->error() == QNetworkReply::OperationCanceledError)
+	// Aborted or connection error
+	if (m_loadDetails->error())
 	{
+		if (m_loadDetails->error() != QNetworkReply::OperationCanceledError)
+			log(QStringLiteral("Loading error: %1").arg(m_loadDetails->errorString()), Logger::Error);
 		m_loadDetails->deleteLater();
 		m_loadDetails = nullptr;
 		return;

--- a/lib/src/models/image.cpp
+++ b/lib/src/models/image.cpp
@@ -379,7 +379,8 @@ void Image::parseDetails()
 	ParsedDetails ret = api->parseDetails(source, statusCode, m_parentSite);
 	if (!ret.error.isEmpty())
 	{
-		log(QStringLiteral("[%1][%2] %3").arg(m_parentSite->url(), api->getName(), ret.error), Logger::Warning);
+		auto logLevel = m_detailsParsWarnAsErr ? Logger::Error : Logger::Warning;
+		log(QStringLiteral("[%1][%2] %3").arg(m_parentSite->url(), api->getName(), ret.error), logLevel);
 		emit finishedLoadingTags();
 		return;
 	}
@@ -659,6 +660,7 @@ bool Image::isGallery() const { return m_isGallery; }
 ExtensionRotator *Image::extensionRotator() const { return m_extensionRotator; }
 QString Image::extension() const { return getExtension(m_url).toLower(); }
 
+void Image::setPromoteDetailParsWarn(bool val) { m_detailsParsWarnAsErr = val; }
 void Image::setPreviewImage(const QPixmap &preview)
 {
 	m_sizes[Image::Size::Thumbnail]->setPixmap(preview);

--- a/lib/src/models/image.h
+++ b/lib/src/models/image.h
@@ -66,6 +66,7 @@ class Image : public QObject, public Downloadable
 		bool isGallery() const;
 		QString extension() const;
 		void setParentGallery(const QSharedPointer<Image> &parentGallery);
+		void setPromoteDetailParsWarn(bool);
 
 		// Preview pixmap store
 		QPixmap previewImage() const;
@@ -136,6 +137,7 @@ class Image : public QObject, public Downloadable
 		bool m_loadingDetails, m_loadedDetails;
 		bool m_isGallery = false;
 		int m_galleryCount;
+		bool m_detailsParsWarnAsErr = false;
 		QSharedPointer<Image> m_parentGallery;
 		QMap<Image::Size, QSharedPointer<ImageSize>> m_sizes;
 };


### PR DESCRIPTION
I made the grabber-cli capable of outputting json.

### Changed
* `-d`
  Sets loglevel to `Logger::Debug` and prints log to stdout, even without QT_DEBUG.

* __Image::parseDetails()__
  logs `reply.error() != 0` as error, if it's not OperationCanceledError.

* **exit on error**
	When using cli, the `Logger::log()` will throw if `Logger::Error` gets logged.
	If wanted, errors can be ignored with the `--ignore-error` Option.

### Added
#### cli options
* `--no-login`
	stops the automatic login attemp by using `site::setAutoLogin()`

* `--proxy`
  sets proxy via `QNetworkProxy::setApplicationProxy`

* `-j`:
  output all available details of all found images as json to stdout

* `--load-details`
  When using `-j`, load details of every image. Uses asyncron requests.

* `--get-details <url-page>`
  load details and print them as json

I wanted the cli to exit if it encounters a parsing error, by logging an error.
So I came up with `Image::setPromoteDetailParsWarn(bool)`
Maybe it would be a better solution to check `!id`, or `file_url.isEmpty()`.
