### PR TITLE
Use mkpath instead of mkdir to ensure path exists

### DIFF
--- a/lib/src/functions.cpp
+++ b/lib/src/functions.cpp
@@ -294,7 +294,7 @@ bool copyRecursively(QString srcFilePath, QString tgtFilePath)
 	// Try to create the target directory
 	QDir targetDir(tgtFilePath);
 	targetDir.cdUp();
-	if (!targetDir.mkdir(QDir(tgtFilePath).dirName())) {
+	if (!targetDir.mkpath(QDir(tgtFilePath).dirName())) {
 		return false;
 	}
 


### PR DESCRIPTION
This ensures a directory exists before settings files are copied to a writable location. Fixes #1761 