### PR TITLE
Default writable to true so settings can be saved on Linux

### DIFF
--- a/lib/src/functions.h
+++ b/lib/src/functions.h
@@ -32,7 +32,7 @@ class QSettings;
 
 
 QDateTime qDateTimeFromString(const QString &str);
-QString savePath(const QString &file = "", bool exists = false, bool writable = false);
+QString savePath(const QString &file = "", bool exists = false, bool writable = true);
 bool copyRecursively(QString srcFilePath, QString tgtFilePath);
 int levenshtein(QString, QString);
 QString stripTags(QString);


### PR DESCRIPTION
Properly fixes #1761 

With this change settings properly save for me and there are no errors about temp files in the log.