### PR TITLE
Added a missing include to fix compilation on Arch

### DIFF
--- a/src/gui/src/ui/QBouton.cpp
+++ b/src/gui/src/ui/QBouton.cpp
@@ -1,5 +1,6 @@
 #include "ui/QBouton.h"
 #include <QPainter>
+#include <QPainterPath>
 #include <QPaintEvent>
 #include <QtMath>
 


### PR DESCRIPTION
The compilation kept failing, including the AUR imgbrd-grabber-git package. This fixes it.