### PR TITLE
Develop builds are on travis-ci.org, not github

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Grabber works on Windows, Mac, and Linux. It is available in English, French, Ru
 ## Download
 You can download the latest release [here](https://github.com/Bionus/imgbrd-grabber/releases/latest), or find all previous releases [here](https://github.com/Bionus/imgbrd-grabber/releases).
 
-For users interested, a nightly version is built automatically on every commit on the `develop` branch, and can be downloaded [here](https://github.com/Bionus/imgbrd-grabber/releases/nightly). Note that it might be less stable than official releases, so use at your own risk.
+For users interested, a nightly version is built automatically on every commit on the `develop` branch, and can be downloaded [here](https://travis-ci.org/github/Bionus/imgbrd-grabber/builds). Note that it might be less stable than official releases, so use at your own risk.
 
 ## Features
 


### PR DESCRIPTION
Resolves #2177

(Note the changes to the contributors list are line-endings only)