### PR TITLE
Update Gelbooru URL links

### DIFF
--- a/src/sites/Gelbooru (0.2)/model.ts
+++ b/src/sites/Gelbooru (0.2)/model.ts
@@ -1,7 +1,8 @@
 function completeImage(img: IImage): IImage {
     if ((!img.file_url || img.file_url.length < 5) && img.preview_url) {
         img.file_url = img.preview_url
-            .replace("/thumbnails/", "/images/")
+            .replace("thumbs", "img2")
+            .replace("gelbooru.com/", "gelbooru.com/images/")
             .replace("/thumbnail_", "/");
     }
 


### PR DESCRIPTION
As stated in Issue https://github.com/Bionus/imgbrd-grabber/issues/2179, Gelbooru's thumbnail and url have changed their subdomains. 
This fixes both the HTML and XML parsing

XML output:
https://gelbooru.com/index.php?page=dapi&s=post&q=index&limit=40&pid=0&tags=haruhi_suzumiya
![image](https://user-images.githubusercontent.com/35495603/99150747-af89dc00-26d1-11eb-85ee-62dfe6cf3693.png)

As seen, the file_url and preview_url have differed in both the HTML and XML data from the previous model.ts
