### PR TITLE
Fix deprecations

### DIFF
--- a/src/cli/src/main.cpp
+++ b/src/cli/src/main.cpp
@@ -135,7 +135,7 @@ int main(int argc, char *argv[])
 		log(QStringLiteral("Enabling application proxy on host \"%1\" and port %2.").arg(proxyUrl.host()).arg(proxyUrl.port()), Logger::Info);
 	}
 
-	auto sites = profile->getFilteredSites(parser.value(sourceOption).split(" ", QString::SkipEmptyParts));
+	auto sites = profile->getFilteredSites(parser.value(sourceOption).split(" ", Qt::SkipEmptyParts));
 	if (parser.isSet(noLoginOption)) {
 		for (auto& site : sites) {
 			site->setAutoLogin(false);
@@ -179,8 +179,8 @@ int main(int argc, char *argv[])
 
 	QString blacklistOverride = parser.value(tagsBlacklistOption);
 	Downloader *downloader = new Downloader(profile, printer,
-		parser.value(tagsOption).split(" ", QString::SkipEmptyParts),
-		parser.value(postFilteringOption).split(" ", QString::SkipEmptyParts),
+		parser.value(tagsOption).split(" ", Qt::SkipEmptyParts),
+		parser.value(postFilteringOption).split(" ", Qt::SkipEmptyParts),
 		sites,
 		parser.value(pageOption).toInt(),
 		parser.value(limitOption).toInt(),

--- a/src/gui-qml/src/main-screen.cpp
+++ b/src/gui-qml/src/main-screen.cpp
@@ -246,8 +246,8 @@ QString MainScreen::getBlacklist()
 void MainScreen::setBlacklist(const QString &text)
 {
 	Blacklist blacklist;
-	for (const QString &tags : text.split("\n", QString::SkipEmptyParts)) {
-		blacklist.add(tags.trimmed().split(' ', QString::SkipEmptyParts));
+	for (const QString &tags : text.split("\n", Qt::SkipEmptyParts)) {
+		blacklist.add(tags.trimmed().split(' ', Qt::SkipEmptyParts));
 	}
 	m_profile->setBlacklistedTags(blacklist);
 }
@@ -259,5 +259,5 @@ QString MainScreen::getIgnored()
 
 void MainScreen::setIgnored(const QString &ignored)
 {
-	m_profile->setIgnored(ignored.split('\n', QString::SkipEmptyParts));
+	m_profile->setIgnored(ignored.split('\n', Qt::SkipEmptyParts));
 }

--- a/src/gui/src/batch/add-group-window.cpp
+++ b/src/gui/src/batch/add-group-window.cpp
@@ -38,8 +38,8 @@ AddGroupWindow::AddGroupWindow(Site *selected, Profile *profile, QWidget *parent
  */
 void AddGroupWindow::ok()
 {
-	const QStringList tags = m_lineTags->toPlainText().split(' ', QString::SkipEmptyParts);
-	const QStringList postFiltering = m_linePostFiltering->toPlainText().split(' ', QString::SkipEmptyParts);
+	const QStringList tags = m_lineTags->toPlainText().split(' ', Qt::SkipEmptyParts);
+	const QStringList postFiltering = m_linePostFiltering->toPlainText().split(' ', Qt::SkipEmptyParts);
 	Site *site = m_sites.value(ui->comboSites->currentText());
 	emit sendData(DownloadQueryGroup(tags, ui->spinPage->value(), ui->spinPP->value(), ui->spinLimit->value(), postFiltering, ui->checkBlacklist->isChecked(), site, m_settings->value("Save/filename").toString(), m_settings->value("Save/path").toString()));
 	close();

--- a/src/gui/src/batch/add-unique-window.cpp
+++ b/src/gui/src/batch/add-unique-window.cpp
@@ -104,7 +104,7 @@ void AddUniqueWindow::ok(bool close)
 	m_close = close;
 	Api *api = site->detailsApi();
 
-	const QStringList ids = ui->lineId->toPlainText().split('\n', QString::SkipEmptyParts);
+	const QStringList ids = ui->lineId->toPlainText().split('\n', Qt::SkipEmptyParts);
 	for (const QString &id : ids) {
 		UniqueQuery q;
 		q.site = site;
@@ -113,7 +113,7 @@ void AddUniqueWindow::ok(bool close)
 		m_queue.enqueue(q);
 	}
 
-	const QStringList md5s = ui->lineMd5->toPlainText().split('\n', QString::SkipEmptyParts);
+	const QStringList md5s = ui->lineMd5->toPlainText().split('\n', Qt::SkipEmptyParts);
 	for (const QString &md5 : md5s) {
 		UniqueQuery q;
 		q.site = site;

--- a/src/gui/src/docks/settings-dock.cpp
+++ b/src/gui/src/docks/settings-dock.cpp
@@ -23,7 +23,7 @@ SettingsDock::SettingsDock(Profile *profile, QWidget *parent)
 	ui->lineFolder->setCompleter(new QCompleter(m_lineFolder_completer, ui->lineFolder));
 	// m_lineFilename_completer = QStringList(m_settings->value("Save/filename").toString());
 	// ui->lineFilename->setCompleter(new QCompleter(m_lineFilename_completer));
-	ui->comboFilename->setAutoCompletionCaseSensitivity(Qt::CaseSensitive);
+	ui->comboFilename->completer()->setCaseSensitivity(Qt::CaseSensitive);
 }
 
 SettingsDock::~SettingsDock()

--- a/src/gui/src/download-group-table-model.cpp
+++ b/src/gui/src/download-group-table-model.cpp
@@ -123,7 +123,7 @@ bool DownloadGroupTableModel::setData(const QModelIndex &index, const QVariant &
 	{
 		case 1:
 			if (download.query.gallery.isNull()) {
-				download.query.tags = val.split(' ', QString::SkipEmptyParts);
+				download.query.tags = val.split(' ', Qt::SkipEmptyParts);
 			}
 			break;
 
@@ -164,7 +164,7 @@ bool DownloadGroupTableModel::setData(const QModelIndex &index, const QVariant &
 			break;
 
 		case 8:
-			download.postFiltering = val.split(' ', QString::SkipEmptyParts);
+			download.postFiltering = val.split(' ', Qt::SkipEmptyParts);
 			break;
 
 		case 9:

--- a/src/gui/src/favorite-window.cpp
+++ b/src/gui/src/favorite-window.cpp
@@ -113,7 +113,7 @@ void FavoriteWindow::save()
 		ui->lastViewedDateTimeEdit->dateTime(),
 		monitors,
 		savePath("thumbs/" + m_favorite.getName(true) + ".png"),
-		ui->postFilteringLineEdit->text().split(' ', QString::SkipEmptyParts),
+		ui->postFilteringLineEdit->text().split(' ', Qt::SkipEmptyParts),
 		m_selectedSources
 	);
 

--- a/src/gui/src/main-window.cpp
+++ b/src/gui/src/main-window.cpp
@@ -373,7 +373,7 @@ void MainWindow::parseArgs(const QStringList &args, const QMap<QString, QString>
 
 	// Other positional arguments are treated as tags
 	tags.append(args);
-	tags.append(params.value("tags").split(' ', QString::SkipEmptyParts));
+	tags.append(params.value("tags").split(' ', Qt::SkipEmptyParts));
 	if (!tags.isEmpty() || m_settings->value("start", "restore").toString() == "firstpage") {
 		loadTag(tags.join(' '), true, false, false);
 	}

--- a/src/gui/src/main/main.cpp
+++ b/src/gui/src/main/main.cpp
@@ -202,7 +202,7 @@ int main(int argc, char *argv[])
 			exit(1);
 		}
 
-		auto sites = profile->getFilteredSites(parser.value(sourceOption).split(" ", QString::SkipEmptyParts));
+		auto sites = profile->getFilteredSites(parser.value(sourceOption).split(" ", Qt::SkipEmptyParts));
 		if (sites.isEmpty()) {
 			QTextStream(stderr) << "No valid source found";
 			exit(1);
@@ -214,8 +214,8 @@ int main(int argc, char *argv[])
 
 		QString blacklistOverride = parser.value(tagsBlacklistOption);
 		Downloader *downloader = new Downloader(profile, printer,
-			parser.value(tagsOption).split(" ", QString::SkipEmptyParts),
-			parser.value(postFilteringOption).split(" ", QString::SkipEmptyParts),
+			parser.value(tagsOption).split(" ", Qt::SkipEmptyParts),
+			parser.value(postFilteringOption).split(" ", Qt::SkipEmptyParts),
 			sites,
 			parser.value(pageOption).toInt(),
 			parser.value(limitOption).toInt(),

--- a/src/gui/src/monitor-window.cpp
+++ b/src/gui/src/monitor-window.cpp
@@ -57,8 +57,8 @@ void MonitorWindow::save()
 {
 	int index = m_monitorManager->remove(m_monitor);
 
-	SearchQuery query = !m_monitor.query().gallery.isNull() ? m_monitor.query() : ui->lineSearch->text().split(' ', QString::SkipEmptyParts);
-	QStringList postFilters = ui->linePostFilters->text().split(' ', QString::SkipEmptyParts);
+	SearchQuery query = !m_monitor.query().gallery.isNull() ? m_monitor.query() : ui->lineSearch->text().split(' ', Qt::SkipEmptyParts);
+	QStringList postFilters = ui->linePostFilters->text().split(' ', Qt::SkipEmptyParts);
 	int interval = ui->spinInterval->value() * 60;
 	int delay = ui->spinDelay->value() * 60;
 	bool notify = ui->checkNotificationEnabled->isChecked();

--- a/src/gui/src/monitoring-center.cpp
+++ b/src/gui/src/monitoring-center.cpp
@@ -37,7 +37,7 @@ void MonitoringCenter::start()
 
 void MonitoringCenter::checkMonitor(Monitor &monitor, const Favorite &favorite)
 {
-	bool newImages = checkMonitor(monitor, favorite.getName().split(' ', QString::SkipEmptyParts), favorite.getPostFiltering());
+	bool newImages = checkMonitor(monitor, favorite.getName().split(' ', Qt::SkipEmptyParts), favorite.getPostFiltering());
 	if (newImages) {
 		emit m_profile->favoritesChanged();
 	}

--- a/src/gui/src/settings/options-window.cpp
+++ b/src/gui/src/settings/options-window.cpp
@@ -898,15 +898,15 @@ void OptionsWindow::save()
 
 	// Blacklist
 	Blacklist blacklist;
-	for (const QString &tags : ui->textBlacklist->toPlainText().split("\n", QString::SkipEmptyParts)) {
-		blacklist.add(tags.trimmed().split(' ', QString::SkipEmptyParts));
+	for (const QString &tags : ui->textBlacklist->toPlainText().split("\n", Qt::SkipEmptyParts)) {
+		blacklist.add(tags.trimmed().split(' ', Qt::SkipEmptyParts));
 	}
 	m_profile->setBlacklistedTags(blacklist);
 	settings->setValue("downloadblacklist", ui->checkDownloadBlacklisted->isChecked());
 
 	// Ignored tags
 	settings->setValue("ignoredtags", ui->textRemovedTags->toPlainText());
-	m_profile->setIgnored(ui->textIgnoredTags->toPlainText().split('\n', QString::SkipEmptyParts));
+	m_profile->setIgnored(ui->textIgnoredTags->toPlainText().split('\n', Qt::SkipEmptyParts));
 
 	// Monitoring
 	settings->beginGroup("Monitoring");

--- a/src/gui/src/sources/sources-settings-window.cpp
+++ b/src/gui/src/sources/sources-settings-window.cpp
@@ -214,7 +214,7 @@ void SourcesSettingsWindow::deleteSite()
 		QString sites = f.readAll();
 		f.close();
 		sites.replace("\r\n", "\n").replace("\r", "\n").replace("\n", "\r\n");
-		QStringList stes = sites.split("\r\n", QString::SkipEmptyParts);
+		QStringList stes = sites.split("\r\n", Qt::SkipEmptyParts);
 		stes.removeAll(m_site->url());
 		f.open(QIODevice::WriteOnly);
 		f.write(stes.join("\r\n").toLatin1());

--- a/src/gui/src/tabs/downloads-tab.cpp
+++ b/src/gui/src/tabs/downloads-tab.cpp
@@ -188,11 +188,11 @@ void DownloadsTab::batchClearSel()
 }
 void DownloadsTab::batchClearSelGroups()
 {
-	batchRemoveGroups(selectedRows(ui->tableBatchGroups).toList());
+	batchRemoveGroups(selectedRows(ui->tableBatchGroups).values());
 }
 void DownloadsTab::batchClearSelUniques()
 {
-	batchRemoveUniques(selectedRows(ui->tableBatchUniques).toList());
+	batchRemoveUniques(selectedRows(ui->tableBatchUniques).values());
 }
 void DownloadsTab::batchRemoveGroups(QList<int> rows)
 {
@@ -227,7 +227,7 @@ void DownloadsTab::batchRemoveUniques(QList<int> rows)
 
 void DownloadsTab::batchMove(int diff)
 {
-	QList<int> rows = selectedRows(ui->tableBatchGroups).toList();
+	QList<int> rows = selectedRows(ui->tableBatchGroups).values();
 	if (rows.isEmpty()) {
 		return;
 	}
@@ -1122,8 +1122,8 @@ void DownloadsTab::getAllFinished()
 
 	// Remove after download and retries are finished
 	if (m_progressDialog->endRemove()) {
-		batchRemoveGroups(m_batchDownloading.toList());
-		batchRemoveUniques(m_batchUniqueDownloading.toList());
+		batchRemoveGroups(m_batchDownloading.values());
+		batchRemoveUniques(m_batchUniqueDownloading.values());
 	}
 
 	// End of batch download

--- a/src/gui/src/tabs/downloads-tab.cpp
+++ b/src/gui/src/tabs/downloads-tab.cpp
@@ -777,7 +777,7 @@ void DownloadsTab::getAllImages()
 
 	// We start the simultaneous downloads
 	int count = qMax(1, qMin(m_settings->value("Save/simultaneous").toInt(), 10));
-	m_getAllCurrentlyProcessing.store(count);
+	m_getAllCurrentlyProcessing.storeRelaxed(count);
 	for (int i = 0; i < count; i++) {
 		_getAll();
 	}
@@ -1021,7 +1021,7 @@ void DownloadsTab::getAllSkip()
 
 	m_getAllSkipped += count;
 	m_progressDialog->setTotalValue(m_getAllDownloaded + m_getAllExists + m_getAllIgnored + m_getAllErrors + m_getAllResumed);
-	m_getAllCurrentlyProcessing.store(count);
+	m_getAllCurrentlyProcessing.storeRelaxed(count);
 	for (int i = 0; i < count; ++i) {
 		_getAll();
 	}

--- a/src/gui/src/tabs/favorites-tab.cpp
+++ b/src/gui/src/tabs/favorites-tab.cpp
@@ -201,7 +201,7 @@ void FavoritesTab::load()
 {
 	updateTitle();
 
-	loadTags(m_currentTags.trimmed().split(' ', QString::SkipEmptyParts));
+	loadTags(m_currentTags.trimmed().split(' ', Qt::SkipEmptyParts));
 }
 
 bool FavoritesTab::validateImage(const QSharedPointer<Image> &img, QString &error)
@@ -249,7 +249,7 @@ void FavoritesTab::getPage()
 
 	QList<QSharedPointer<Page>> pages = this->getPagesToDownload();
 	for (const QSharedPointer<Page> &page : pages) {
-		const QStringList search = (m_currentTags + " " + m_settings->value("add").toString().toLower().trimmed()).split(' ', QString::SkipEmptyParts);
+		const QStringList search = (m_currentTags + " " + m_settings->value("add").toString().toLower().trimmed()).split(' ', Qt::SkipEmptyParts);
 		const int perpage = unloaded ? ui->spinImagesPerPage->value() : page->pageImageCount();
 		const QStringList postFiltering = postFilter(true);
 
@@ -269,7 +269,7 @@ void FavoritesTab::getAll()
 			continue;
 		}
 
-		const QStringList search = (m_currentTags + " " + m_settings->value("add").toString().toLower().trimmed()).split(' ', QString::SkipEmptyParts);
+		const QStringList search = (m_currentTags + " " + m_settings->value("add").toString().toLower().trimmed()).split(' ', Qt::SkipEmptyParts);
 		const QStringList postFiltering = postFilter(true);
 
 		emit batchAddGroup(DownloadQueryGroup(m_settings, search, 1, perPage, total, postFiltering, page->site()));

--- a/src/gui/src/tabs/image-preview.cpp
+++ b/src/gui/src/tabs/image-preview.cpp
@@ -6,6 +6,7 @@
 #include <QLabel>
 #include <QMenu>
 #include <QMovie>
+#include <QRandomGenerator>
 #include <QSettings>
 #include <QtMath>
 #include <QUrl>
@@ -292,7 +293,7 @@ void ImagePreview::contextSaveImageAs()
 
 	// If the MD5 is required for the filename, we first download the image
 	if (format.needTemporaryFile(m_image->tokens(m_profile))) {
-		tmpPath = QDir::temp().absoluteFilePath("grabber-saveAs-" + QString::number(qrand(), 16));
+		tmpPath = QDir::temp().absoluteFilePath("grabber-saveAs-" + QString::number(QRandomGenerator::global()->generate(), 16));
 
 		QEventLoop loop;
 		ImageDownloader downloader(m_profile, m_image, { tmpPath }, 1, true, true, this);

--- a/src/gui/src/tabs/pool-tab.cpp
+++ b/src/gui/src/tabs/pool-tab.cpp
@@ -83,7 +83,7 @@ void PoolTab::load()
 
 	// Get the search values
 	QString search = m_search->toPlainText();
-	QStringList tags = search.trimmed().split(" ", QString::SkipEmptyParts);
+	QStringList tags = search.trimmed().split(" ", Qt::SkipEmptyParts);
 	tags.prepend("pool:" + QString::number(ui->spinPool->value()));
 
 	loadTags(tags);
@@ -101,7 +101,7 @@ void PoolTab::write(QJsonObject &json) const
 	json["type"] = QStringLiteral("pool");
 	json["pool"] = ui->spinPool->value();
 	json["site"] = ui->comboSites->currentText();
-	json["tags"] = QJsonArray::fromStringList(m_search->toPlainText().split(' ', QString::SkipEmptyParts));
+	json["tags"] = QJsonArray::fromStringList(m_search->toPlainText().split(' ', Qt::SkipEmptyParts));
 	json["page"] = ui->spinPage->value();
 	json["perpage"] = ui->spinImagesPerPage->value();
 	json["columns"] = ui->spinColumns->value();
@@ -149,7 +149,7 @@ void PoolTab::getPage()
 	}
 
 	const int perPage = unloaded ? ui->spinImagesPerPage->value() : page->pageImageCount();
-	const QStringList tags = ("pool:" + QString::number(ui->spinPool->value()) + " " + m_search->toPlainText() + " " + m_settings->value("add").toString().trimmed()).split(' ', QString::SkipEmptyParts);
+	const QStringList tags = ("pool:" + QString::number(ui->spinPool->value()) + " " + m_search->toPlainText() + " " + m_settings->value("add").toString().trimmed()).split(' ', Qt::SkipEmptyParts);
 	const QStringList postFiltering = postFilter(true);
 	Site *site = m_sites.value(ui->comboSites->currentText());
 
@@ -174,7 +174,7 @@ void PoolTab::getAll()
 		return;
 	}
 
-	const QStringList search = ("pool:" + QString::number(ui->spinPool->value()) + " " + m_search->toPlainText() + " " + m_settings->value("add").toString().trimmed()).split(' ', QString::SkipEmptyParts);
+	const QStringList search = ("pool:" + QString::number(ui->spinPool->value()) + " " + m_search->toPlainText() + " " + m_settings->value("add").toString().trimmed()).split(' ', Qt::SkipEmptyParts);
 	const QStringList postFiltering = postFilter(true);
 	Site *site = m_sites.value(ui->comboSites->currentText());
 

--- a/src/gui/src/tabs/search-tab.cpp
+++ b/src/gui/src/tabs/search-tab.cpp
@@ -546,7 +546,7 @@ void SearchTab::finishedLoadingPreview()
 
 	// Download whitelist images on thumbnail view
 	Blacklist whitelistedTags;
-	for (const QString &tag : m_settings->value("whitelistedtags").toString().split(" ", QString::SkipEmptyParts)) {
+	for (const QString &tag : m_settings->value("whitelistedtags").toString().split(" ", Qt::SkipEmptyParts)) {
 		whitelistedTags.add(tag);
 	}
 	QStringList detected = m_profile->getBlacklist().match(img->tokens(m_profile));
@@ -779,8 +779,8 @@ void SearchTab::setPageLabelText(QLabel *txt, Page *page, const QList<QSharedPoi
 	}
 
 	/*if (page->search().join(" ") != m_search->toPlainText() && m_settings->value("showtagwarning", true).toBool()) {
-		QStringList uncommon = m_search->toPlainText().toLower().trimmed().split(" ", QString::SkipEmptyParts);
-		uncommon.append(m_settings->value("add").toString().toLower().trimmed().split(" ", QString::SkipEmptyParts));
+		QStringList uncommon = m_search->toPlainText().toLower().trimmed().split(" ", Qt::SkipEmptyParts);
+		uncommon.append(m_settings->value("add").toString().toLower().trimmed().split(" ", Qt::SkipEmptyParts));
 		for (int i = 0; i < page->search().size(); i++) {
 			if (uncommon.contains(page->search().at(i))) {
 				uncommon.removeAll(page->search().at(i));
@@ -1193,7 +1193,7 @@ void SearchTab::loadTags(SearchQuery query)
 
 	// Append "additional tags" setting
 	if (query.gallery.isNull()) {
-		query.tags.append(m_settings->value("add").toString().trimmed().split(" ", QString::SkipEmptyParts));
+		query.tags.append(m_settings->value("add").toString().trimmed().split(" ", Qt::SkipEmptyParts));
 	}
 
 	// Save previous pages
@@ -1454,7 +1454,7 @@ QStringList SearchTab::postFilter(bool includeGlobal) const
 			ret += " " + globalPostFilter;
 		}
 	}
-	return ret.split(' ', QString::SkipEmptyParts);
+	return ret.split(' ', Qt::SkipEmptyParts);
 }
 
 const QString &SearchTab::screenName() const

--- a/src/gui/src/tabs/tag-tab.cpp
+++ b/src/gui/src/tabs/tag-tab.cpp
@@ -99,14 +99,14 @@ void TagTab::load()
 		}
 	}
 
-	const QStringList tags = search.split(" ", QString::SkipEmptyParts);
+	const QStringList tags = search.split(" ", Qt::SkipEmptyParts);
 	loadTags(tags);
 }
 
 void TagTab::write(QJsonObject &json) const
 {
 	json["type"] = QStringLiteral("tag");
-	json["tags"] = QJsonArray::fromStringList(m_search->toPlainText().split(' ', QString::SkipEmptyParts));
+	json["tags"] = QJsonArray::fromStringList(m_search->toPlainText().split(' ', Qt::SkipEmptyParts));
 	json["page"] = ui->spinPage->value();
 	json["perpage"] = ui->spinImagesPerPage->value();
 	json["columns"] = ui->spinColumns->value();
@@ -244,7 +244,7 @@ void TagTab::getAll()
 }
 void TagTab::monitor()
 {
-	const QStringList tags = m_search->toPlainText().trimmed().split(" ", QString::SkipEmptyParts);
+	const QStringList tags = m_search->toPlainText().trimmed().split(" ", Qt::SkipEmptyParts);
 	const bool notify = m_settings->value("Monitoring/enableTray", false).toBool();
 	Monitor monitor(loadSites(), 24 * 60 * 60, QDateTime::currentDateTimeUtc(), true, QString(), QString(), 0, true, tags, postFilter(), notify);
 	m_profile->monitorManager()->add(monitor);

--- a/src/gui/src/ui/text-edit.cpp
+++ b/src/gui/src/ui/text-edit.cpp
@@ -29,7 +29,7 @@ QSize TextEdit::sizeHint() const
 {
 	QFontMetrics fm(font());
 	const int h = qMax(fm.height(), 14) + 4;
-	const int w = fm.width(QLatin1Char('x')) * 17 + 4;
+	const int w = fm.horizontalAdvance(QLatin1Char('x')) * 17 + 4;
 	QStyleOptionFrame opt;
 	opt.initFrom(this);
 	return (style()->sizeFromContents(QStyle::CT_LineEdit, &opt, QSize(w, h).expandedTo(QApplication::globalStrut()), this));

--- a/src/gui/src/updater/update-dialog.cpp
+++ b/src/gui/src/updater/update-dialog.cpp
@@ -94,7 +94,7 @@ void UpdateDialog::downloadFinished(const QString &path)
 	ui->progressDownload->setValue(ui->progressDownload->maximum());
 
 	#if !defined(QT_NO_PROCESS)
-		QProcess::startDetached(path);
+		QProcess::startDetached(path, QStringList());
 	#endif
 
 	if (m_parent != nullptr) {

--- a/src/gui/src/utils/blacklist-fix/blacklist-fix-1.cpp
+++ b/src/gui/src/utils/blacklist-fix/blacklist-fix-1.cpp
@@ -122,8 +122,8 @@ void BlacklistFix1::getAll(Page *p)
 		page->load();
 	} else {
 		Blacklist blacklist;
-		for (const QString &tags : ui->textBlacklist->toPlainText().split("\n", QString::SkipEmptyParts)) {
-			blacklist.add(tags.trimmed().split(' ', QString::SkipEmptyParts));
+		for (const QString &tags : ui->textBlacklist->toPlainText().split("\n", Qt::SkipEmptyParts)) {
+			blacklist.add(tags.trimmed().split(' ', Qt::SkipEmptyParts));
 		}
 
 		BlacklistFix2 *bf2 = new BlacklistFix2(m_getAll.values(), blacklist);

--- a/src/gui/src/viewer/zoom-window.cpp
+++ b/src/gui/src/viewer/zoom-window.cpp
@@ -158,7 +158,7 @@ void ZoomWindow::go()
 	ui->labelPools->hide();
 	bool whitelisted = false;
 	if (!m_settings->value("whitelistedtags").toString().isEmpty()) {
-		QStringList whitelist = m_settings->value("whitelistedtags").toString().split(" ", QString::SkipEmptyParts);
+		QStringList whitelist = m_settings->value("whitelistedtags").toString().split(" ", Qt::SkipEmptyParts);
 		for (const Tag &t : m_image->tags()) {
 			if (whitelist.contains(t.text())) {
 				whitelisted = true;

--- a/src/gui/src/viewer/zoom-window.cpp
+++ b/src/gui/src/viewer/zoom-window.cpp
@@ -15,6 +15,7 @@
 #include <QMouseEvent>
 #include <QMovie>
 #include <QPainter>
+#include <QScreen>
 #include <QScrollBar>
 #include <QShortcut>
 #include <QUrl>
@@ -432,7 +433,7 @@ void ZoomWindow::display(const QPixmap &pix, int size)
 		updateWindowTitle();
 
 		if (m_isFullscreen && m_fullScreen != nullptr && m_fullScreen->isVisible()) {
-			m_fullScreen->setImage(m_displayImage.scaled(QApplication::desktop()->screenGeometry().size(), Qt::KeepAspectRatio, Qt::SmoothTransformation));
+			m_fullScreen->setImage(m_displayImage.scaled(QGuiApplication::primaryScreen()->geometry().width(), QGuiApplication::primaryScreen()->geometry().height(), Qt::KeepAspectRatio, Qt::SmoothTransformation));
 		}
 	}
 }
@@ -730,7 +731,7 @@ void ZoomWindow::draw()
 		update();
 
 		if (m_isFullscreen && m_fullScreen != nullptr && m_fullScreen->isVisible()) {
-			m_fullScreen->setImage(m_displayImage.scaled(QApplication::desktop()->screenGeometry().size(), Qt::KeepAspectRatio, Qt::SmoothTransformation));
+			m_fullScreen->setImage(m_displayImage.scaled(QGuiApplication::primaryScreen()->geometry().width(), QGuiApplication::primaryScreen()->geometry().height(), Qt::KeepAspectRatio, Qt::SmoothTransformation));
 		}
 	}
 }
@@ -993,7 +994,7 @@ void ZoomWindow::fullScreen()
 		if (!m_isAnimated.isEmpty()) {
 			m_fullScreen->setMovie(m_displayMovie);
 		} else {
-			m_fullScreen->setImage(m_displayImage.scaled(QApplication::desktop()->screenGeometry().size(), Qt::KeepAspectRatio, Qt::SmoothTransformation));
+			m_fullScreen->setImage(m_displayImage.scaled(QGuiApplication::primaryScreen()->geometry().width(), QGuiApplication::primaryScreen()->geometry().height(), Qt::KeepAspectRatio, Qt::SmoothTransformation));
 		}
 		m_fullScreen->setWindowFlags(Qt::Window);
 		m_fullScreen->showFullScreen();

--- a/src/gui/src/viewer/zoom-window.cpp
+++ b/src/gui/src/viewer/zoom-window.cpp
@@ -433,7 +433,7 @@ void ZoomWindow::display(const QPixmap &pix, int size)
 		updateWindowTitle();
 
 		if (m_isFullscreen && m_fullScreen != nullptr && m_fullScreen->isVisible()) {
-			m_fullScreen->setImage(m_displayImage.scaled(QGuiApplication::primaryScreen()->geometry().width(), QGuiApplication::primaryScreen()->geometry().height(), Qt::KeepAspectRatio, Qt::SmoothTransformation));
+			m_fullScreen->setImage(m_displayImage.scaled(QGuiApplication::primaryScreen()->geometry().size(), Qt::KeepAspectRatio, Qt::SmoothTransformation));
 		}
 	}
 }
@@ -731,7 +731,7 @@ void ZoomWindow::draw()
 		update();
 
 		if (m_isFullscreen && m_fullScreen != nullptr && m_fullScreen->isVisible()) {
-			m_fullScreen->setImage(m_displayImage.scaled(QGuiApplication::primaryScreen()->geometry().width(), QGuiApplication::primaryScreen()->geometry().height(), Qt::KeepAspectRatio, Qt::SmoothTransformation));
+			m_fullScreen->setImage(m_displayImage.scaled(QGuiApplication::primaryScreen()->geometry().size(), Qt::KeepAspectRatio, Qt::SmoothTransformation));
 		}
 	}
 }
@@ -994,7 +994,7 @@ void ZoomWindow::fullScreen()
 		if (!m_isAnimated.isEmpty()) {
 			m_fullScreen->setMovie(m_displayMovie);
 		} else {
-			m_fullScreen->setImage(m_displayImage.scaled(QGuiApplication::primaryScreen()->geometry().width(), QGuiApplication::primaryScreen()->geometry().height(), Qt::KeepAspectRatio, Qt::SmoothTransformation));
+			m_fullScreen->setImage(m_displayImage.scaled(QGuiApplication::primaryScreen()->geometry().size(), Qt::KeepAspectRatio, Qt::SmoothTransformation));
 		}
 		m_fullScreen->setWindowFlags(Qt::Window);
 		m_fullScreen->showFullScreen();

--- a/src/lib/src/concurrent-multi-queue.cpp
+++ b/src/lib/src/concurrent-multi-queue.cpp
@@ -26,7 +26,7 @@ void ConcurrentMultiQueue::append(int queue, QVariant item)
 
 	m_queues[queue].append(item);
 
-	if (m_activeWorkers.load() < m_globalConcurrency) {
+	if (m_activeWorkers.loadRelaxed() < m_globalConcurrency) {
 		m_activeWorkers.fetchAndAddRelaxed(1);
 		next();
 	}

--- a/src/lib/src/downloader/batch-downloader.cpp
+++ b/src/lib/src/downloader/batch-downloader.cpp
@@ -145,7 +145,7 @@ void BatchDownloader::nextImages()
 
 	// Start the simultaneous downloads
 	int count = qMax(1, qMin(m_settings->value("Save/simultaneous").toInt(), 10));
-	m_currentlyProcessing.store(count); // TODO: this should be shared amongst instances
+	m_currentlyProcessing.storeRelaxed(count); // TODO: this should be shared amongst instances
 	for (int i = 0; i < count; ++i) {
 		nextImage();
 	}

--- a/src/lib/src/functions.cpp
+++ b/src/lib/src/functions.cpp
@@ -484,9 +484,9 @@ void shutDown(int timeout)
 {
 	#if !defined(QT_NO_PROCESS)
 		#if defined(Q_OS_WIN)
-			QProcess::startDetached("shutdown -s -f -t " + QString::number(timeout));
+			QProcess::startDetached(QString("shutdown"), QStringList({"-s", "-f", "-t", QString::number(timeout)}));
 		#else
-			QProcess::startDetached("shutdown " + QString::number(timeout));
+			QProcess::startDetached(QString("shutdown"), QStringList({QString::number(timeout)}));
 		#endif
 	#endif
 }
@@ -498,9 +498,9 @@ void openTray()
 {
 	#if !defined(QT_NO_PROCESS)
 		#if defined(Q_OS_WIN)
-			QProcess::startDetached(QStringLiteral("CDR.exe open"));
+			QProcess::startDetached(QString("CDR.exe"), QStringList({"open"}));
 		#else
-			QProcess::startDetached(QStringLiteral("eject cdrom"));
+			QProcess::startDetached(QString("eject"), QStringList({"cdrom"}));
 		#endif
 	#endif
 }

--- a/src/lib/src/models/api/javascript-api.cpp
+++ b/src/lib/src/models/api/javascript-api.cpp
@@ -147,7 +147,7 @@ QList<Tag> JavascriptApi::makeTags(const QJSValue &tags, Site *site) const
 			if (tag.property("related").isArray()) {
 				related = jsToStringList(tag.property("related"));
 			} else {
-				related = tag.property("related").toString().split(' ', QString::SkipEmptyParts);
+				related = tag.property("related").toString().split(' ', Qt::SkipEmptyParts);
 			}
 		}
 

--- a/src/lib/src/models/image-factory.cpp
+++ b/src/lib/src/models/image-factory.cpp
@@ -116,7 +116,7 @@ vTransformToken ImageFactory::parseTypedTags(const QString &type)
 		QList<Tag> tagList = data["tags"].value<QList<Tag>>();
 
 		const TagType tagType(type);
-		QStringList tags = val.split(' ', QString::SkipEmptyParts);
+		QStringList tags = val.split(' ', Qt::SkipEmptyParts);
 		for (QString tag : tags) {
 			tag.replace("&amp;", "&");
 			tagList.append(Tag(tag, tagType));
@@ -144,8 +144,8 @@ void ImageFactory::parseTags(const QString &val, QVariantMap &data)
 	const int commas = raw.count(", ");
 	const int spaces = raw.count(" ");
 	const QStringList &tags = commas >= 10 || (commas > 0 && (spaces - commas) / commas < 2)
-		? raw.split(", ", QString::SkipEmptyParts)
-		: raw.split(" ", QString::SkipEmptyParts);
+		? raw.split(", ", Qt::SkipEmptyParts)
+		: raw.split(" ", Qt::SkipEmptyParts);
 
 	for (QString tg : tags) {
 		tg.replace("&amp;", "&");

--- a/src/lib/src/models/image.cpp
+++ b/src/lib/src/models/image.cpp
@@ -988,7 +988,7 @@ QMap<QString, Token> Image::generateTokens(Profile *profile) const
 {
 	QSettings *settings = profile->getSettings();
 	QStringList ignore = profile->getIgnored();
-	const QStringList remove = settings->value("ignoredtags").toString().split(' ', QString::SkipEmptyParts);
+	const QStringList remove = settings->value("ignoredtags").toString().split(' ', Qt::SkipEmptyParts);
 
 	QMap<QString, Token> tokens;
 

--- a/src/lib/src/models/page.cpp
+++ b/src/lib/src/models/page.cpp
@@ -25,7 +25,7 @@ Page::Page(Profile *profile, Site *site, const QList<Site*> &sites, SearchQuery 
 			.replace(" -rating:s ", " -rating:safe ", Qt::CaseInsensitive)
 			.replace(" -rating:q ", " -rating:questionable ", Qt::CaseInsensitive)
 			.replace(" -rating:e ", " -rating:explicit ", Qt::CaseInsensitive);
-		QStringList tags = text.split(" ", QString::SkipEmptyParts);
+		QStringList tags = text.split(" ", Qt::SkipEmptyParts);
 
 		// Get the list of all enabled modifiers
 		QStringList modifiers = QStringList();

--- a/src/lib/src/models/profile.cpp
+++ b/src/lib/src/models/profile.cpp
@@ -73,7 +73,7 @@ Profile::Profile(QString path)
 			QString favs = fileFavorites.readAll();
 			fileFavorites.close();
 
-			QStringList words = favs.split("\n", QString::SkipEmptyParts);
+			QStringList words = favs.split("\n", Qt::SkipEmptyParts);
 			m_favorites.reserve(words.count());
 			for (const QString &word : words) {
 				Favorite fav = Favorite::fromString(m_path, word);
@@ -91,7 +91,7 @@ Profile::Profile(QString path)
 		QString vil = fileKfl.readAll();
 		fileKfl.close();
 
-		m_keptForLater = vil.split("\n", QString::SkipEmptyParts);
+		m_keptForLater = vil.split("\n", Qt::SkipEmptyParts);
 	}
 
 	// Load ignored
@@ -100,7 +100,7 @@ Profile::Profile(QString path)
 		QString ign = fileIgnored.readAll();
 		fileIgnored.close();
 
-		m_ignored = ign.split("\n", QString::SkipEmptyParts);
+		m_ignored = ign.split("\n", Qt::SkipEmptyParts);
 	}
 
 	// Make a backup of MD5s in case the multi-location change broke everything
@@ -118,7 +118,7 @@ Profile::Profile(QString path)
 	if (fileAutoComplete.open(QFile::ReadOnly | QFile::Text)) {
 		QString line;
 		while (!(line = fileAutoComplete.readLine()).isEmpty()) {
-			m_autoComplete.append(line.trimmed().split(" ", QString::SkipEmptyParts));
+			m_autoComplete.append(line.trimmed().split(" ", Qt::SkipEmptyParts));
 		}
 
 		fileAutoComplete.close();
@@ -129,7 +129,7 @@ Profile::Profile(QString path)
 	if (fileCustomAutoComplete.open(QFile::ReadOnly | QFile::Text)) {
 		QString line;
 		while (!(line = fileCustomAutoComplete.readLine()).isEmpty()) {
-			m_customAutoComplete.append(line.trimmed().split(" ", QString::SkipEmptyParts));
+			m_customAutoComplete.append(line.trimmed().split(" ", Qt::SkipEmptyParts));
 		}
 
 		fileCustomAutoComplete.close();
@@ -138,7 +138,7 @@ Profile::Profile(QString path)
 	m_commands = new Commands(this);
 
 	// Blacklisted tags
-	const QStringList &blacklist = m_settings->value("blacklistedtags").toString().split(' ', QString::SkipEmptyParts);
+	const QStringList &blacklist = m_settings->value("blacklistedtags").toString().split(' ', Qt::SkipEmptyParts);
 	for (const QString &bl : blacklist) {
 		m_blacklist.add(bl);
 	}
@@ -148,7 +148,7 @@ Profile::Profile(QString path)
 		while (!(line = fileBlacklist.readLine()).isEmpty()) {
 			line = line.trimmed();
 			if (!line.startsWith('#')) {
-				m_blacklist.add(line.split(" ", QString::SkipEmptyParts));
+				m_blacklist.add(line.split(" ", Qt::SkipEmptyParts));
 			}
 		}
 
@@ -428,7 +428,7 @@ void Profile::addSite(Site *site)
 	QString sites = f.readAll();
 	f.close();
 	sites.replace("\r\n", "\n").replace("\r", "\n").replace("\n", "\r\n");
-	QStringList stes = sites.split("\r\n", QString::SkipEmptyParts);
+	QStringList stes = sites.split("\r\n", Qt::SkipEmptyParts);
 	stes.append(site->url());
 	stes.removeDuplicates();
 	stes.sort();

--- a/src/lib/src/vendor/simplecrypt.cpp
+++ b/src/lib/src/vendor/simplecrypt.cpp
@@ -31,6 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <QDateTime>
 #include <QCryptographicHash>
 #include <QDataStream>
+#include <QRandomGenerator>
 
 SimpleCrypt::SimpleCrypt():
     m_key(0),
@@ -38,7 +39,6 @@ SimpleCrypt::SimpleCrypt():
     m_protectionMode(ProtectionChecksum),
     m_lastError(ErrorNoError)
 {
-    qsrand(uint(QDateTime::currentMSecsSinceEpoch() & 0xFFFF));
 }
 
 SimpleCrypt::SimpleCrypt(quint64 key):
@@ -47,7 +47,6 @@ SimpleCrypt::SimpleCrypt(quint64 key):
     m_protectionMode(ProtectionChecksum),
     m_lastError(ErrorNoError)
 {
-    qsrand(uint(QDateTime::currentMSecsSinceEpoch() & 0xFFFF));
     splitKey();
 }
 
@@ -113,7 +112,7 @@ QByteArray SimpleCrypt::encryptToByteArray(const QByteArray &plaintext)
     }
 
     //prepend a random char to the string
-    char randomChar = char(qrand() & 0xFF);
+    char randomChar = char(QRandomGenerator::global()->generate() & 0xFF);
     ba = randomChar + integrityProtection + ba;
 
     int pos(0);

--- a/src/tests/src/models/md5-database/md5-database-text-test.cpp
+++ b/src/tests/src/models/md5-database/md5-database-text-test.cpp
@@ -41,7 +41,7 @@ TEST_CASE("Md5DatabaseText")
 
 		QFile f("tests/resources/md5s.txt");
 		f.open(QFile::ReadOnly | QFile::Text);
-		QStringList lines = QString(f.readAll()).split("\n", QString::SkipEmptyParts);
+		QStringList lines = QString(f.readAll()).split("\n", Qt::SkipEmptyParts);
 		f.close();
 
 		REQUIRE(lines.count() == 4);
@@ -63,7 +63,7 @@ TEST_CASE("Md5DatabaseText")
 
 		QFile f("tests/resources/md5s.txt");
 		f.open(QFile::ReadOnly | QFile::Text);
-		QStringList lines = QString(f.readAll()).split("\n", QString::SkipEmptyParts);
+		QStringList lines = QString(f.readAll()).split("\n", Qt::SkipEmptyParts);
 		f.close();
 
 		REQUIRE(lines.count() == 4);
@@ -101,7 +101,7 @@ TEST_CASE("Md5DatabaseText")
 
 		QFile f("tests/resources/md5s.txt");
 		f.open(QFile::ReadOnly | QFile::Text);
-		QStringList lines = QString(f.readAll()).split("\n", QString::SkipEmptyParts);
+		QStringList lines = QString(f.readAll()).split("\n", Qt::SkipEmptyParts);
 		f.close();
 
 		REQUIRE(lines.count() == 1);
@@ -118,7 +118,7 @@ TEST_CASE("Md5DatabaseText")
 
 		QFile f("tests/resources/md5s.txt");
 		f.open(QFile::ReadOnly | QFile::Text);
-		QStringList lines = QString(f.readAll()).split("\n", QString::SkipEmptyParts);
+		QStringList lines = QString(f.readAll()).split("\n", Qt::SkipEmptyParts);
 		f.close();
 
 		REQUIRE(lines.count() == 2);


### PR DESCRIPTION
I've replaced most of the deprecated methods with recommended ones.

I haven't touched any QTime methods since QElapsedTimer is monotonic and doesn't allow for conversion to human readable time. I've seen at least one instance of conversion to human readable time.
I also haven't touched QJSEngine because there is no alternative for the deprecated method.
There is another deprecation warning, but it didn't make sense to me so I left it alone. It's just a `return nullptr` but the output is this:
```
/home/txtsd/git/imgbrd-grabber/src/gui/src/ui/fixed-size-grid-layout.cpp: In member function ‘virtual Qt::Orientations FixedSizeGridLayout::expandingDirections() const’:
/home/txtsd/git/imgbrd-grabber/src/gui/src/ui/fixed-size-grid-layout.cpp:89:9: warning: ‘constexpr QFlags<T>::QFlags(QFlags<T>::Zero) [with Enum = Qt::Orientation; QFlags<T>::Zero = int QFlags<Qt::Orientation>::Private::*]’ is deprecated: Use default constructor instead [-Wdeprecated-declarations]
   89 |  return nullptr;
      |         ^~~~~~~
In file included from /usr/include/qt/QtCore/qglobal.h:1304,
                 from /usr/include/qt/QtGui/qtguiglobal.h:43,
                 from /usr/include/qt/QtWidgets/qtwidgetsglobal.h:43,
                 from /usr/include/qt/QtWidgets/qlayout.h:43,
                 from /usr/include/qt/QtWidgets/QLayout:1,
                 from /home/txtsd/git/imgbrd-grabber/src/gui/src/ui/fixed-size-grid-layout.h:4,
                 from /home/txtsd/git/imgbrd-grabber/src/gui/src/ui/fixed-size-grid-layout.cpp:1:
/usr/include/qt/QtCore/qflags.h:123:80: note: declared here
  123 |     QT_DEPRECATED_X("Use default constructor instead") Q_DECL_CONSTEXPR inline QFlags(Zero) noexcept : i(0) {}
      |       
```

Let me know if any behavior has changed.