### PR TITLE
Fix issue with dangling pointer when calling utime

### DIFF
--- a/src/lib/src/functions.cpp
+++ b/src/lib/src/functions.cpp
@@ -456,8 +456,7 @@ bool setFileCreationDate(const QString &path, const QDateTime &datetime)
 	#else
 		struct utimbuf timebuffer;
 		timebuffer.modtime = datetime.toTime_t();
-		const char *filename = path.toStdString().c_str();
-		if ((utime(filename, &timebuffer)) < 0) {
+		if ((utime(path.toStdString().c_str(), &timebuffer)) < 0) {
 			log(QStringLiteral("Unable to change the file creation date (%1 - %2): %3").arg(lastError()).arg(lastErrorString(), path), Logger::Error);
 			return false;
 		}

--- a/src/lib/src/functions.cpp
+++ b/src/lib/src/functions.cpp
@@ -456,6 +456,7 @@ bool setFileCreationDate(const QString &path, const QDateTime &datetime)
 	#else
 		struct utimbuf timebuffer;
 		timebuffer.modtime = datetime.toTime_t();
+		timebuffer.actime = QDateTime::currentDateTimeUtc().toTime_t();
 		if ((utime(path.toStdString().c_str(), &timebuffer)) < 0) {
 			log(QStringLiteral("Unable to change the file creation date (%1 - %2): %3").arg(lastError()).arg(lastErrorString(), path), Logger::Error);
 			return false;


### PR DESCRIPTION
The temporary string object returned by the function call is
deallocated at the end of the expression. Since c_str() returns a
pointer to the internal string representation, the data is no longer
valid once the string object is destroyed. Due to this utime returns
ENOENT and Grabber prints an error in the log when modifying
file creation time.
Fixes https://github.com/Bionus/imgbrd-grabber/issues/2203
I don't think this issue affects Windows, since toWcharT is directly called on path variable. Maybe someone can check in Windows.