### PR TITLE
Fix for pixiv login

### DIFF
--- a/src/lib/src/auth/oauth2-auth.cpp
+++ b/src/lib/src/auth/oauth2-auth.cpp
@@ -39,5 +39,16 @@ QList<AuthSettingField> OAuth2Auth::settingFields() const
 		fields.append(passwordField);
 	}
 
+	if (m_authType == "refresh_token") {
+		AuthSettingField accessTokenField;
+		accessTokenField.id = "accessToken";
+
+		AuthSettingField refreshTokenField;
+		refreshTokenField.id = "refreshToken";
+
+		fields.append(accessTokenField);
+		fields.append(refreshTokenField);
+	}
+
 	return fields;
 }

--- a/src/lib/src/login/oauth2-login.cpp
+++ b/src/lib/src/login/oauth2-login.cpp
@@ -76,6 +76,9 @@ void OAuth2Login::login()
 				body << QStrP("client_secret", consumerSecret);
 			}
 		}
+	} else if (type == "refresh_token") {
+		refresh(true);
+		return;
 	}
 
 	// Post request and wait for a reply

--- a/src/sites/Pixiv/model.ts
+++ b/src/sites/Pixiv/model.ts
@@ -118,7 +118,7 @@ export const source: ISource = {
     auth: {
         oauth2: {
             type: "oauth2",
-            authType: "password",
+            authType: "refresh_token",
             tokenUrl: "https://oauth.secure.pixiv.net/auth/token",
         },
     },

--- a/src/sites/types.d.ts
+++ b/src/sites/types.d.ts
@@ -131,7 +131,7 @@ interface IAuthCheckMaxPage {
 type IAuth = IBasicAuth | IOauth2Auth | IHttpAuth | IHttpBasicAuth;
 interface IOauth2Auth {
     type: "oauth2";
-    authType: "password" | "client_credentials" | "header_basic";
+    authType: "password" | "client_credentials" | "header_basic" | "refresh_token";
     requestUrl?: string;
     tokenUrl?: string;
     refreshTokenUrl?: string;


### PR DESCRIPTION
This is a quick (and might dirty) fix for pixiv login,
which is a workaround suggested in pixivpy[\[^1\]][1].
This PR do:

* add an oauth type "refresh_token" which simply use user-supplied tokens to authenticate,
* some UI modifications that allow user to set access_token and refresh_token,
* set pixiv's oauth type to refresh_token.

[1]: https://github.com/upbit/pixivpy/blob/master/pixivpy3/api.py#L81
