### PR TITLE
Customisable Shortcuts

### DIFF
--- a/src/gui/src/main-window.cpp
+++ b/src/gui/src/main-window.cpp
@@ -186,19 +186,19 @@ void MainWindow::init(const QStringList &args, const QMap<QString, QString> &par
 	}
 
 	m_settings->beginGroup("Main/Shortcuts");
-		ui->actionClosetab->setShortcut(getKeySequence(m_settings, "keyMainCloseTab", Qt::CTRL + Qt::Key_W));
+		ui->actionClosetab->setShortcut(getKeySequence(m_settings, "keyCloseTab", Qt::CTRL + Qt::Key_W));
 
-		QShortcut *actionFocusSearch = new QShortcut(getKeySequence(m_settings, "keyMainFocusSearch", Qt::CTRL + Qt::Key_L), this);
+		QShortcut *actionFocusSearch = new QShortcut(getKeySequence(m_settings, "keyFocusSearch", Qt::CTRL + Qt::Key_L), this);
 			connect(actionFocusSearch, &QShortcut::activated, this, &MainWindow::focusSearch);
 
-		QShortcut *actionPrevTab = new QShortcut(getKeySequence(m_settings, "keyMainPrevTab", Qt::CTRL + Qt::Key_PageDown), this);
+		QShortcut *actionPrevTab = new QShortcut(getKeySequence(m_settings, "keyPrevTab", Qt::CTRL + Qt::Key_PageDown), this);
 			connect(actionPrevTab, &QShortcut::activated, this, &MainWindow::tabPrev);
-		QShortcut *actionNextTab = new QShortcut(getKeySequence(m_settings, "keyMainNextTab", Qt::CTRL + Qt::Key_PageUp), this);
+		QShortcut *actionNextTab = new QShortcut(getKeySequence(m_settings, "keyNextTab", Qt::CTRL + Qt::Key_PageUp), this);
 			connect(actionNextTab, &QShortcut::activated, this, &MainWindow::tabNext);
 
-		ui->actionAddtab->setShortcut(getKeySequence(m_settings, "keyMainNewTab", QKeySequence::AddTab, Qt::CTRL + Qt::Key_T));
-		ui->actionQuit->setShortcut(getKeySequence(m_settings, "keyMainQuit", QKeySequence::Quit, Qt::CTRL + Qt::Key_Q));
-		ui->actionFolder->setShortcut(getKeySequence(m_settings, "keyMainBrowseSave", QKeySequence::Open, Qt::CTRL + Qt::Key_B));
+		ui->actionAddtab->setShortcut(getKeySequence(m_settings, "keyNewTab", QKeySequence::AddTab, Qt::CTRL + Qt::Key_T));
+		ui->actionQuit->setShortcut(getKeySequence(m_settings, "keyQuit", QKeySequence::Quit, Qt::CTRL + Qt::Key_Q));
+		ui->actionFolder->setShortcut(getKeySequence(m_settings, "keyBrowseSave", QKeySequence::Open, Qt::CTRL + Qt::Key_B));
 	m_settings->endGroup();
 
 	connect(ui->actionQuit, &QAction::triggered, this, &QMainWindow::close);

--- a/src/gui/src/main-window.cpp
+++ b/src/gui/src/main-window.cpp
@@ -185,21 +185,22 @@ void MainWindow::init(const QStringList &args, const QMap<QString, QString> &par
 		m_trayIcon = nullptr;
 	}
 
-	ui->actionClosetab->setShortcut(QKeySequence::Close);
-	QShortcut *actionCloseTabW = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_W), this);
-	connect(actionCloseTabW, &QShortcut::activated, ui->actionClosetab, &QAction::trigger);
+	m_settings->beginGroup("Main/Shortcuts");
+		QShortcut *actionFocusSearch = new QShortcut(m_settings->value("keyMainFocusSearch", QKeySequence(Qt::Key_S)).toString(), this);
+			connect(actionFocusSearch, &QShortcut::activated, this, &MainWindow::focusSearch);
 
-	QShortcut *actionFocusSearch = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_L), this);
-	connect(actionFocusSearch, &QShortcut::activated, this, &MainWindow::focusSearch);
+		QShortcut *actionCloseTabW = new QShortcut(m_settings->value("keyMainCloseTab", QKeySequence(Qt::CTRL + Qt::Key_W)).toString(), this);
+			connect(actionCloseTabW, &QShortcut::activated, ui->actionClosetab, &QAction::trigger);
 
-	QShortcut *actionNextTab = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_PageDown), this);
-	connect(actionNextTab, &QShortcut::activated, this, &MainWindow::tabNext);
-	QShortcut *actionPrevTab = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_PageUp), this);
-	connect(actionPrevTab, &QShortcut::activated, this, &MainWindow::tabPrev);
+		QShortcut *actionPrevTab = new QShortcut(m_settings->value("keyMainPrevTab", QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_Tab)).toString(), this);
+			connect(actionPrevTab, &QShortcut::activated, this, &MainWindow::tabPrev);
+		QShortcut *actionNextTab = new QShortcut(m_settings->value("keyMainNextTab", QKeySequence(Qt::CTRL + Qt::Key_Tab)).toString(), this);
+			connect(actionNextTab, &QShortcut::activated, this, &MainWindow::tabNext);
 
-	ui->actionAddtab->setShortcut(QKeySequence::AddTab);
-	ui->actionQuit->setShortcut(QKeySequence::Quit);
-	ui->actionFolder->setShortcut(QKeySequence::Open);
+		ui->actionAddtab->setShortcut(m_settings->value("keyMainNewTab", QKeySequence(Qt::CTRL + Qt::Key_T)).toString());
+		ui->actionQuit->setShortcut(m_settings->value("keyMainQuit", QKeySequence(Qt::CTRL + Qt::Key_Q)).toString());
+		ui->actionFolder->setShortcut(m_settings->value("keyMainBrowseSave", QKeySequence(Qt::CTRL + Qt::Key_O)).toString());
+	m_settings->endGroup();
 
 	connect(ui->actionQuit, &QAction::triggered, this, &QMainWindow::close);
 	connect(ui->actionAboutQt, &QAction::triggered, qApp, &QApplication::aboutQt);

--- a/src/gui/src/main-window.cpp
+++ b/src/gui/src/main-window.cpp
@@ -199,7 +199,7 @@ void MainWindow::init(const QStringList &args, const QMap<QString, QString> &par
 
 		ui->actionAddtab->setShortcut(m_settings->value("keyMainNewTab", QKeySequence(Qt::CTRL + Qt::Key_T)).toString());
 		ui->actionQuit->setShortcut(m_settings->value("keyMainQuit", QKeySequence(Qt::CTRL + Qt::Key_Q)).toString());
-		ui->actionFolder->setShortcut(m_settings->value("keyMainBrowseSave", QKeySequence(Qt::CTRL + Qt::Key_O)).toString());
+		ui->actionFolder->setShortcut(m_settings->value("keyMainBrowseSave", QKeySequence(Qt::CTRL + Qt::Key_B)).toString());
 	m_settings->endGroup();
 
 	connect(ui->actionQuit, &QAction::triggered, this, &QMainWindow::close);

--- a/src/gui/src/main-window.cpp
+++ b/src/gui/src/main-window.cpp
@@ -186,20 +186,19 @@ void MainWindow::init(const QStringList &args, const QMap<QString, QString> &par
 	}
 
 	m_settings->beginGroup("Main/Shortcuts");
-		QShortcut *actionFocusSearch = new QShortcut(m_settings->value("keyMainFocusSearch", QKeySequence(Qt::Key_S)).toString(), this);
+		ui->actionClosetab->setShortcut(getKeySequence(m_settings, "keyMainCloseTab", Qt::CTRL + Qt::Key_W));
+
+		QShortcut *actionFocusSearch = new QShortcut(getKeySequence(m_settings, "keyMainFocusSearch", Qt::CTRL + Qt::Key_L), this);
 			connect(actionFocusSearch, &QShortcut::activated, this, &MainWindow::focusSearch);
 
-		QShortcut *actionCloseTabW = new QShortcut(m_settings->value("keyMainCloseTab", QKeySequence(Qt::CTRL + Qt::Key_W)).toString(), this);
-			connect(actionCloseTabW, &QShortcut::activated, ui->actionClosetab, &QAction::trigger);
-
-		QShortcut *actionPrevTab = new QShortcut(m_settings->value("keyMainPrevTab", QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_Tab)).toString(), this);
+		QShortcut *actionPrevTab = new QShortcut(getKeySequence(m_settings, "keyMainPrevTab", Qt::CTRL + Qt::Key_PageDown), this);
 			connect(actionPrevTab, &QShortcut::activated, this, &MainWindow::tabPrev);
-		QShortcut *actionNextTab = new QShortcut(m_settings->value("keyMainNextTab", QKeySequence(Qt::CTRL + Qt::Key_Tab)).toString(), this);
+		QShortcut *actionNextTab = new QShortcut(getKeySequence(m_settings, "keyMainNextTab", Qt::CTRL + Qt::Key_PageUp), this);
 			connect(actionNextTab, &QShortcut::activated, this, &MainWindow::tabNext);
 
-		ui->actionAddtab->setShortcut(m_settings->value("keyMainNewTab", QKeySequence(Qt::CTRL + Qt::Key_T)).toString());
-		ui->actionQuit->setShortcut(m_settings->value("keyMainQuit", QKeySequence(Qt::CTRL + Qt::Key_Q)).toString());
-		ui->actionFolder->setShortcut(m_settings->value("keyMainBrowseSave", QKeySequence(Qt::CTRL + Qt::Key_B)).toString());
+		ui->actionAddtab->setShortcut(getKeySequence(m_settings, "keyMainNewTab", QKeySequence::AddTab, Qt::CTRL + Qt::Key_T));
+		ui->actionQuit->setShortcut(getKeySequence(m_settings, "keyMainQuit", QKeySequence::Quit, Qt::CTRL + Qt::Key_Q));
+		ui->actionFolder->setShortcut(getKeySequence(m_settings, "keyMainBrowseSave", QKeySequence::Open, Qt::CTRL + Qt::Key_B));
 	m_settings->endGroup();
 
 	connect(ui->actionQuit, &QAction::triggered, this, &QMainWindow::close);

--- a/src/gui/src/main-window.cpp
+++ b/src/gui/src/main-window.cpp
@@ -198,7 +198,7 @@ void MainWindow::init(const QStringList &args, const QMap<QString, QString> &par
 
 		ui->actionAddtab->setShortcut(getKeySequence(m_settings, "keyNewTab", QKeySequence::AddTab, Qt::CTRL + Qt::Key_T));
 		ui->actionQuit->setShortcut(getKeySequence(m_settings, "keyQuit", QKeySequence::Quit, Qt::CTRL + Qt::Key_Q));
-		ui->actionFolder->setShortcut(getKeySequence(m_settings, "keyBrowseSave", QKeySequence::Open, Qt::CTRL + Qt::Key_B));
+		ui->actionFolder->setShortcut(getKeySequence(m_settings, "keyBrowseSave", QKeySequence::Open, Qt::CTRL + Qt::Key_O));
 	m_settings->endGroup();
 
 	connect(ui->actionQuit, &QAction::triggered, this, &QMainWindow::close);

--- a/src/gui/src/settings/options-window.cpp
+++ b/src/gui/src/settings/options-window.cpp
@@ -307,13 +307,13 @@ OptionsWindow::OptionsWindow(Profile *profile, ThemeLoader *themeLoader, QWidget
 	ui->spinSlideshow->setValue(settings->value("slideshow", 0).toInt());
 
 	settings->beginGroup("Main/Shortcuts");
-		ui->keyMainQuit->setKeySequence(getKeySequence(settings, "keyMainQuit", QKeySequence::Quit, Qt::CTRL + Qt::Key_Q));
-		ui->keyMainFocusSearch->setKeySequence(getKeySequence(settings, "keyMainFocusSearch", Qt::CTRL + Qt::Key_L));
-		ui->keyMainCloseTab->setKeySequence(getKeySequence(settings, "keyMainCloseTab", Qt::CTRL + Qt::Key_W));
-		ui->keyMainNewTab->setKeySequence(getKeySequence(settings, "keyMainNewTab", QKeySequence::AddTab, Qt::CTRL + Qt::Key_T));
-		ui->keyMainPrevTab->setKeySequence(getKeySequence(settings, "keyMainPrevTab", Qt::CTRL + Qt::Key_PageDown));
-		ui->keyMainNextTab->setKeySequence(getKeySequence(settings, "keyMainNextTab", Qt::CTRL + Qt::Key_PageUp));
-		ui->keyMainBrowseSave->setKeySequence(getKeySequence(settings, "keyMainBrowseSave", QKeySequence::Open, Qt::CTRL + Qt::Key_B));
+		ui->keyMainQuit->setKeySequence(getKeySequence(settings, "keyQuit", QKeySequence::Quit, Qt::CTRL + Qt::Key_Q));
+		ui->keyMainFocusSearch->setKeySequence(getKeySequence(settings, "keyFocusSearch", Qt::CTRL + Qt::Key_L));
+		ui->keyMainCloseTab->setKeySequence(getKeySequence(settings, "keyCloseTab", Qt::CTRL + Qt::Key_W));
+		ui->keyMainNewTab->setKeySequence(getKeySequence(settings, "keyNewTab", QKeySequence::AddTab, Qt::CTRL + Qt::Key_T));
+		ui->keyMainPrevTab->setKeySequence(getKeySequence(settings, "keyPrevTab", Qt::CTRL + Qt::Key_PageDown));
+		ui->keyMainNextTab->setKeySequence(getKeySequence(settings, "keyNextTab", Qt::CTRL + Qt::Key_PageUp));
+		ui->keyMainBrowseSave->setKeySequence(getKeySequence(settings, "keyBrowseSave", QKeySequence::Open, Qt::CTRL + Qt::Key_B));
 	settings->endGroup();
 
 	ui->checkResultsScrollArea->setChecked(settings->value("resultsScrollArea", true).toBool());
@@ -339,20 +339,20 @@ OptionsWindow::OptionsWindow(Profile *profile, ThemeLoader *themeLoader, QWidget
 	ui->lineImageBackgroundColor->setText(settings->value("imageBackgroundColor", QString()).toString());
 
 	settings->beginGroup("Zoom/Shortcuts");
-		ui->keyViewerQuit->setKeySequence(getKeySequence(settings, "keyViewerQuit", Qt::Key_Escape));
-		ui->keyViewerPrev->setKeySequence(getKeySequence(settings, "keyViewerPrev", Qt::Key_Left));
-		ui->keyViewerNext->setKeySequence(getKeySequence(settings, "keyViewerNext", Qt::Key_Right));
-		ui->keyViewerDetails->setKeySequence(getKeySequence(settings, "keyViewerDetails", Qt::Key_D));
-		ui->keyViewerSaveAs->setKeySequence(getKeySequence(settings, "keyViewerSaveAs", QKeySequence::SaveAs, Qt::CTRL + Qt::SHIFT + Qt::Key_S));
-		ui->keyViewerSave->setKeySequence(getKeySequence(settings, "keyViewerSave", QKeySequence::Save, Qt::CTRL + Qt::Key_S));
-		ui->keyViewerSaveNQuit->setKeySequence(getKeySequence(settings, "keyViewerSaveNQuit", Qt::CTRL + Qt::Key_W));
-		ui->keyViewerOpen->setKeySequence(getKeySequence(settings, "keyViewerOpen", Qt::CTRL + Qt::Key_B));
-		ui->keyViewerSaveFav->setKeySequence(getKeySequence(settings, "keyViewerSaveFav", Qt::CTRL + Qt::ALT + Qt::Key_S));
-		ui->keyViewerSaveNQuitFav->setKeySequence(getKeySequence(settings, "keyViewerSaveNQuitFav", Qt::CTRL + Qt::ALT + Qt::Key_W));
-		ui->keyViewerOpenFav->setKeySequence(getKeySequence(settings, "keyViewerOpenFav", Qt::CTRL + Qt::ALT + Qt::Key_B));
-		ui->keyViewerToggleSlideshow->setKeySequence(getKeySequence(settings, "keyViewerToggleSlideshow", Qt::Key_Space));
-		ui->keyViewerToggleFullscreen->setKeySequence(getKeySequence(settings, "keyViewerToggleFullscreen", QKeySequence::FullScreen, Qt::Key_F11));
-		ui->keyViewerDataToClipboard->setKeySequence(getKeySequence(settings, "keyViewerDataToClipboard", QKeySequence::Copy, Qt::CTRL + Qt::Key_C));
+		ui->keyViewerQuit->setKeySequence(getKeySequence(settings, "keyQuit", Qt::Key_Escape));
+		ui->keyViewerPrev->setKeySequence(getKeySequence(settings, "keyPrev", Qt::Key_Left));
+		ui->keyViewerNext->setKeySequence(getKeySequence(settings, "keyNext", Qt::Key_Right));
+		ui->keyViewerDetails->setKeySequence(getKeySequence(settings, "keyDetails", Qt::Key_D));
+		ui->keyViewerSaveAs->setKeySequence(getKeySequence(settings, "keySaveAs", QKeySequence::SaveAs, Qt::CTRL + Qt::SHIFT + Qt::Key_S));
+		ui->keyViewerSave->setKeySequence(getKeySequence(settings, "keySave", QKeySequence::Save, Qt::CTRL + Qt::Key_S));
+		ui->keyViewerSaveNQuit->setKeySequence(getKeySequence(settings, "keySaveNQuit", Qt::CTRL + Qt::Key_W));
+		ui->keyViewerOpen->setKeySequence(getKeySequence(settings, "keyOpen", Qt::CTRL + Qt::Key_B));
+		ui->keyViewerSaveFav->setKeySequence(getKeySequence(settings, "keySaveFav", Qt::CTRL + Qt::ALT + Qt::Key_S));
+		ui->keyViewerSaveNQuitFav->setKeySequence(getKeySequence(settings, "keySaveNQuitFav", Qt::CTRL + Qt::ALT + Qt::Key_W));
+		ui->keyViewerOpenFav->setKeySequence(getKeySequence(settings, "keyOpenFav", Qt::CTRL + Qt::ALT + Qt::Key_B));
+		ui->keyViewerToggleSlideshow->setKeySequence(getKeySequence(settings, "keyToggleSlideshow", Qt::Key_Space));
+		ui->keyViewerToggleFullscreen->setKeySequence(getKeySequence(settings, "keyToggleFullscreen", QKeySequence::FullScreen, Qt::Key_F11));
+		ui->keyViewerDataToClipboard->setKeySequence(getKeySequence(settings, "keyDataToClipboard", QKeySequence::Copy, Qt::CTRL + Qt::Key_C));
 	settings->endGroup();
 
 	settings->beginGroup("Coloring");
@@ -1154,13 +1154,13 @@ void OptionsWindow::save()
 	settings->setValue("slideshow", ui->spinSlideshow->value());
 
 	settings->beginGroup("Main/Shortcuts");
-		settings->setValue("keyMainQuit", ui->keyMainQuit->keySequence().toString());
-		settings->setValue("keyMainFocusSearch", ui->keyMainFocusSearch->keySequence().toString());
-		settings->setValue("keyMainCloseTab", ui->keyMainCloseTab->keySequence().toString());
-		settings->setValue("keyMainNewTab", ui->keyMainNewTab->keySequence().toString());
-		settings->setValue("keyMainPrevTab", ui->keyMainPrevTab->keySequence().toString());
-		settings->setValue("keyMainNextTab", ui->keyMainNextTab->keySequence().toString());
-		settings->setValue("keyMainBrowseSave", ui->keyMainBrowseSave->keySequence().toString());
+		settings->setValue("keyQuit", ui->keyMainQuit->keySequence().toString());
+		settings->setValue("keyFocusSearch", ui->keyMainFocusSearch->keySequence().toString());
+		settings->setValue("keyCloseTab", ui->keyMainCloseTab->keySequence().toString());
+		settings->setValue("keyNewTab", ui->keyMainNewTab->keySequence().toString());
+		settings->setValue("keyPrevTab", ui->keyMainPrevTab->keySequence().toString());
+		settings->setValue("keyNextTab", ui->keyMainNextTab->keySequence().toString());
+		settings->setValue("keyBrowseSave", ui->keyMainBrowseSave->keySequence().toString());
 	settings->endGroup();
 
 	settings->setValue("resultsScrollArea", ui->checkResultsScrollArea->isChecked());
@@ -1186,20 +1186,20 @@ void OptionsWindow::save()
 	settings->setValue("imageBackgroundColor", ui->lineImageBackgroundColor->text());
 
 	settings->beginGroup("Zoom/Shortcuts");
-		settings->setValue("keyViewerQuit", ui->keyViewerQuit->keySequence().toString());
-		settings->setValue("keyViewerPrev", ui->keyViewerPrev->keySequence().toString());
-		settings->setValue("keyViewerNext", ui->keyViewerNext->keySequence().toString());
-		settings->setValue("keyViewerDetails", ui->keyViewerDetails->keySequence().toString());
-		settings->setValue("keyViewerSaveAs", ui->keyViewerSaveAs->keySequence().toString());
-		settings->setValue("keyViewerSave", ui->keyViewerSave->keySequence().toString());
-		settings->setValue("keyViewerSaveNQuit", ui->keyViewerSaveNQuit->keySequence().toString());
-		settings->setValue("keyViewerOpen", ui->keyViewerOpen->keySequence().toString());
-		settings->setValue("keyViewerSaveFav", ui->keyViewerSaveFav->keySequence().toString());
-		settings->setValue("keyViewerSaveNQuitFav", ui->keyViewerSaveNQuitFav->keySequence().toString());
-		settings->setValue("keyViewerOpenFav", ui->keyViewerOpenFav->keySequence().toString());
-		settings->setValue("keyViewerToggleSlideshow", ui->keyViewerToggleSlideshow->keySequence().toString());
-		settings->setValue("keyViewerToggleFullscreen", ui->keyViewerToggleFullscreen->keySequence().toString());
-		settings->setValue("keyViewerDataToClipboard", ui->keyViewerDataToClipboard->keySequence().toString());
+		settings->setValue("keyQuit", ui->keyViewerQuit->keySequence().toString());
+		settings->setValue("keyPrev", ui->keyViewerPrev->keySequence().toString());
+		settings->setValue("keyNext", ui->keyViewerNext->keySequence().toString());
+		settings->setValue("keyDetails", ui->keyViewerDetails->keySequence().toString());
+		settings->setValue("keySaveAs", ui->keyViewerSaveAs->keySequence().toString());
+		settings->setValue("keySave", ui->keyViewerSave->keySequence().toString());
+		settings->setValue("keySaveNQuit", ui->keyViewerSaveNQuit->keySequence().toString());
+		settings->setValue("keyOpen", ui->keyViewerOpen->keySequence().toString());
+		settings->setValue("keySaveFav", ui->keyViewerSaveFav->keySequence().toString());
+		settings->setValue("keySaveNQuitFav", ui->keyViewerSaveNQuitFav->keySequence().toString());
+		settings->setValue("keyOpenFav", ui->keyViewerOpenFav->keySequence().toString());
+		settings->setValue("keyToggleSlideshow", ui->keyViewerToggleSlideshow->keySequence().toString());
+		settings->setValue("keyToggleFullscreen", ui->keyViewerToggleFullscreen->keySequence().toString());
+		settings->setValue("keyDataToClipboard", ui->keyViewerDataToClipboard->keySequence().toString());
 	settings->endGroup();
 
 	settings->beginGroup("Coloring");

--- a/src/gui/src/settings/options-window.cpp
+++ b/src/gui/src/settings/options-window.cpp
@@ -313,7 +313,7 @@ OptionsWindow::OptionsWindow(Profile *profile, ThemeLoader *themeLoader, QWidget
 		ui->keyMainNewTab->setKeySequence(settings->value("keyMainNewTab", QKeySequence(Qt::CTRL + Qt::Key_T)).toString());
 		ui->keyMainPrevTab->setKeySequence(settings->value("keyMainPrevTab", QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_Tab)).toString());
 		ui->keyMainNextTab->setKeySequence(settings->value("keyMainNextTab", QKeySequence(Qt::CTRL + Qt::Key_Tab)).toString());
-		ui->keyMainBrowseSave->setKeySequence(settings->value("keyMainBrowseSave", QKeySequence(Qt::CTRL + Qt::Key_O)).toString());
+		ui->keyMainBrowseSave->setKeySequence(settings->value("keyMainBrowseSave", QKeySequence(Qt::CTRL + Qt::Key_B)).toString());
 	settings->endGroup();
 
 	ui->checkResultsScrollArea->setChecked(settings->value("resultsScrollArea", true).toBool());
@@ -346,10 +346,10 @@ OptionsWindow::OptionsWindow(Profile *profile, ThemeLoader *themeLoader, QWidget
 		ui->keyViewerSaveAs->setKeySequence(settings->value("keyViewerSaveAs", QKeySequence(Qt::SHIFT + Qt::Key_S)).toString());
 		ui->keyViewerSave->setKeySequence(settings->value("keyViewerSave", QKeySequence(Qt::Key_S)).toString());
 		ui->keyViewerSaveNQuit->setKeySequence(settings->value("keyViewerSaveNQuit", QKeySequence(Qt::Key_W)).toString());
-		ui->keyViewerOpen->setKeySequence(settings->value("keyViewerOpen", QKeySequence(Qt::Key_T)).toString());
+		ui->keyViewerOpen->setKeySequence(settings->value("keyViewerOpen", QKeySequence(Qt::Key_B)).toString());
 		ui->keyViewerSaveFav->setKeySequence(settings->value("keyViewerSaveFav", QKeySequence(Qt::ALT + Qt::Key_S)).toString());
 		ui->keyViewerSaveNQuitFav->setKeySequence(settings->value("keyViewerSaveNQuitFav", QKeySequence(Qt::ALT + Qt::Key_W)).toString());
-		ui->keyViewerOpenFav->setKeySequence(settings->value("keyViewerOpenFav", QKeySequence(Qt::ALT + Qt::Key_T)).toString());
+		ui->keyViewerOpenFav->setKeySequence(settings->value("keyViewerOpenFav", QKeySequence(Qt::ALT + Qt::Key_B)).toString());
 		ui->keyViewerToggleSlideshow->setKeySequence(settings->value("keyViewerToggleSlideshow", QKeySequence(Qt::Key_Space)).toString());
 		ui->keyViewerToggleFullscreen->setKeySequence(settings->value("keyViewerToggleFullscreen", QKeySequence(Qt::Key_F)).toString());
 		ui->keyViewerDataToClipboard->setKeySequence(settings->value("keyViewerDataToClipboard", QKeySequence(Qt::CTRL + Qt::Key_C)).toString());

--- a/src/gui/src/settings/options-window.cpp
+++ b/src/gui/src/settings/options-window.cpp
@@ -313,7 +313,7 @@ OptionsWindow::OptionsWindow(Profile *profile, ThemeLoader *themeLoader, QWidget
 		ui->keyMainNewTab->setKeySequence(getKeySequence(settings, "keyNewTab", QKeySequence::AddTab, Qt::CTRL + Qt::Key_T));
 		ui->keyMainPrevTab->setKeySequence(getKeySequence(settings, "keyPrevTab", Qt::CTRL + Qt::Key_PageDown));
 		ui->keyMainNextTab->setKeySequence(getKeySequence(settings, "keyNextTab", Qt::CTRL + Qt::Key_PageUp));
-		ui->keyMainBrowseSave->setKeySequence(getKeySequence(settings, "keyBrowseSave", QKeySequence::Open, Qt::CTRL + Qt::Key_B));
+		ui->keyMainBrowseSave->setKeySequence(getKeySequence(settings, "keyBrowseSave", QKeySequence::Open, Qt::CTRL + Qt::Key_O));
 	settings->endGroup();
 
 	ui->checkResultsScrollArea->setChecked(settings->value("resultsScrollArea", true).toBool());
@@ -346,10 +346,10 @@ OptionsWindow::OptionsWindow(Profile *profile, ThemeLoader *themeLoader, QWidget
 		ui->keyViewerSaveAs->setKeySequence(getKeySequence(settings, "keySaveAs", QKeySequence::SaveAs, Qt::CTRL + Qt::SHIFT + Qt::Key_S));
 		ui->keyViewerSave->setKeySequence(getKeySequence(settings, "keySave", QKeySequence::Save, Qt::CTRL + Qt::Key_S));
 		ui->keyViewerSaveNQuit->setKeySequence(getKeySequence(settings, "keySaveNQuit", Qt::CTRL + Qt::Key_W));
-		ui->keyViewerOpen->setKeySequence(getKeySequence(settings, "keyOpen", Qt::CTRL + Qt::Key_B));
+		ui->keyViewerOpen->setKeySequence(getKeySequence(settings, "keyOpen", Qt::CTRL + Qt::Key_O));
 		ui->keyViewerSaveFav->setKeySequence(getKeySequence(settings, "keySaveFav", Qt::CTRL + Qt::ALT + Qt::Key_S));
 		ui->keyViewerSaveNQuitFav->setKeySequence(getKeySequence(settings, "keySaveNQuitFav", Qt::CTRL + Qt::ALT + Qt::Key_W));
-		ui->keyViewerOpenFav->setKeySequence(getKeySequence(settings, "keyOpenFav", Qt::CTRL + Qt::ALT + Qt::Key_B));
+		ui->keyViewerOpenFav->setKeySequence(getKeySequence(settings, "keyOpenFav", Qt::CTRL + Qt::ALT + Qt::Key_O));
 		ui->keyViewerToggleSlideshow->setKeySequence(getKeySequence(settings, "keyToggleSlideshow", Qt::Key_Space));
 		ui->keyViewerToggleFullscreen->setKeySequence(getKeySequence(settings, "keyToggleFullscreen", QKeySequence::FullScreen, Qt::Key_F11));
 		ui->keyViewerDataToClipboard->setKeySequence(getKeySequence(settings, "keyDataToClipboard", QKeySequence::Copy, Qt::CTRL + Qt::Key_C));

--- a/src/gui/src/settings/options-window.cpp
+++ b/src/gui/src/settings/options-window.cpp
@@ -307,13 +307,13 @@ OptionsWindow::OptionsWindow(Profile *profile, ThemeLoader *themeLoader, QWidget
 	ui->spinSlideshow->setValue(settings->value("slideshow", 0).toInt());
 
 	settings->beginGroup("Main/Shortcuts");
-		ui->keyMainQuit->setKeySequence(settings->value("keyMainQuit", QKeySequence(Qt::CTRL + Qt::Key_Q)).toString());
-		ui->keyMainFocusSearch->setKeySequence(settings->value("keyMainFocusSearch", QKeySequence(Qt::Key_S)).toString());
-		ui->keyMainCloseTab->setKeySequence(settings->value("keyMainCloseTab", QKeySequence(Qt::CTRL + Qt::Key_W)).toString());
-		ui->keyMainNewTab->setKeySequence(settings->value("keyMainNewTab", QKeySequence(Qt::CTRL + Qt::Key_T)).toString());
-		ui->keyMainPrevTab->setKeySequence(settings->value("keyMainPrevTab", QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_Tab)).toString());
-		ui->keyMainNextTab->setKeySequence(settings->value("keyMainNextTab", QKeySequence(Qt::CTRL + Qt::Key_Tab)).toString());
-		ui->keyMainBrowseSave->setKeySequence(settings->value("keyMainBrowseSave", QKeySequence(Qt::CTRL + Qt::Key_B)).toString());
+		ui->keyMainQuit->setKeySequence(getKeySequence(settings, "keyMainQuit", QKeySequence::Quit, Qt::CTRL + Qt::Key_Q));
+		ui->keyMainFocusSearch->setKeySequence(getKeySequence(settings, "keyMainFocusSearch", Qt::CTRL + Qt::Key_L));
+		ui->keyMainCloseTab->setKeySequence(getKeySequence(settings, "keyMainCloseTab", Qt::CTRL + Qt::Key_W));
+		ui->keyMainNewTab->setKeySequence(getKeySequence(settings, "keyMainNewTab", QKeySequence::AddTab, Qt::CTRL + Qt::Key_T));
+		ui->keyMainPrevTab->setKeySequence(getKeySequence(settings, "keyMainPrevTab", Qt::CTRL + Qt::Key_PageDown));
+		ui->keyMainNextTab->setKeySequence(getKeySequence(settings, "keyMainNextTab", Qt::CTRL + Qt::Key_PageUp));
+		ui->keyMainBrowseSave->setKeySequence(getKeySequence(settings, "keyMainBrowseSave", QKeySequence::Open, Qt::CTRL + Qt::Key_B));
 	settings->endGroup();
 
 	ui->checkResultsScrollArea->setChecked(settings->value("resultsScrollArea", true).toBool());
@@ -339,20 +339,20 @@ OptionsWindow::OptionsWindow(Profile *profile, ThemeLoader *themeLoader, QWidget
 	ui->lineImageBackgroundColor->setText(settings->value("imageBackgroundColor", QString()).toString());
 
 	settings->beginGroup("Zoom/Shortcuts");
-		ui->keyViewerQuit->setKeySequence(settings->value("keyViewerQuit", QKeySequence(Qt::Key_Q)).toString());
-		ui->keyViewerPrev->setKeySequence(settings->value("keyViewerPrev", QKeySequence(Qt::Key_Left)).toString());
-		ui->keyViewerNext->setKeySequence(settings->value("keyViewerNext", QKeySequence(Qt::Key_Right)).toString());
-		ui->keyViewerDetails->setKeySequence(settings->value("keyViewerDetails", QKeySequence(Qt::Key_D)).toString());
-		ui->keyViewerSaveAs->setKeySequence(settings->value("keyViewerSaveAs", QKeySequence(Qt::SHIFT + Qt::Key_S)).toString());
-		ui->keyViewerSave->setKeySequence(settings->value("keyViewerSave", QKeySequence(Qt::Key_S)).toString());
-		ui->keyViewerSaveNQuit->setKeySequence(settings->value("keyViewerSaveNQuit", QKeySequence(Qt::Key_W)).toString());
-		ui->keyViewerOpen->setKeySequence(settings->value("keyViewerOpen", QKeySequence(Qt::Key_B)).toString());
-		ui->keyViewerSaveFav->setKeySequence(settings->value("keyViewerSaveFav", QKeySequence(Qt::ALT + Qt::Key_S)).toString());
-		ui->keyViewerSaveNQuitFav->setKeySequence(settings->value("keyViewerSaveNQuitFav", QKeySequence(Qt::ALT + Qt::Key_W)).toString());
-		ui->keyViewerOpenFav->setKeySequence(settings->value("keyViewerOpenFav", QKeySequence(Qt::ALT + Qt::Key_B)).toString());
-		ui->keyViewerToggleSlideshow->setKeySequence(settings->value("keyViewerToggleSlideshow", QKeySequence(Qt::Key_Space)).toString());
-		ui->keyViewerToggleFullscreen->setKeySequence(settings->value("keyViewerToggleFullscreen", QKeySequence(Qt::Key_F)).toString());
-		ui->keyViewerDataToClipboard->setKeySequence(settings->value("keyViewerDataToClipboard", QKeySequence(Qt::CTRL + Qt::Key_C)).toString());
+		ui->keyViewerQuit->setKeySequence(getKeySequence(settings, "keyViewerQuit", Qt::Key_Escape));
+		ui->keyViewerPrev->setKeySequence(getKeySequence(settings, "keyViewerPrev", Qt::Key_Left));
+		ui->keyViewerNext->setKeySequence(getKeySequence(settings, "keyViewerNext", Qt::Key_Right));
+		ui->keyViewerDetails->setKeySequence(getKeySequence(settings, "keyViewerDetails", Qt::Key_D));
+		ui->keyViewerSaveAs->setKeySequence(getKeySequence(settings, "keyViewerSaveAs", QKeySequence::SaveAs, Qt::CTRL + Qt::SHIFT + Qt::Key_S));
+		ui->keyViewerSave->setKeySequence(getKeySequence(settings, "keyViewerSave", QKeySequence::Save, Qt::CTRL + Qt::Key_S));
+		ui->keyViewerSaveNQuit->setKeySequence(getKeySequence(settings, "keyViewerSaveNQuit", Qt::CTRL + Qt::Key_W));
+		ui->keyViewerOpen->setKeySequence(getKeySequence(settings, "keyViewerOpen", Qt::CTRL + Qt::Key_B));
+		ui->keyViewerSaveFav->setKeySequence(getKeySequence(settings, "keyViewerSaveFav", Qt::CTRL + Qt::ALT + Qt::Key_S));
+		ui->keyViewerSaveNQuitFav->setKeySequence(getKeySequence(settings, "keyViewerSaveNQuitFav", Qt::CTRL + Qt::ALT + Qt::Key_W));
+		ui->keyViewerOpenFav->setKeySequence(getKeySequence(settings, "keyViewerOpenFav", Qt::CTRL + Qt::ALT + Qt::Key_B));
+		ui->keyViewerToggleSlideshow->setKeySequence(getKeySequence(settings, "keyViewerToggleSlideshow", Qt::Key_Space));
+		ui->keyViewerToggleFullscreen->setKeySequence(getKeySequence(settings, "keyViewerToggleFullscreen", QKeySequence::FullScreen, Qt::Key_F11));
+		ui->keyViewerDataToClipboard->setKeySequence(getKeySequence(settings, "keyViewerDataToClipboard", QKeySequence::Copy, Qt::CTRL + Qt::Key_C));
 	settings->endGroup();
 
 	settings->beginGroup("Coloring");

--- a/src/gui/src/settings/options-window.cpp
+++ b/src/gui/src/settings/options-window.cpp
@@ -305,6 +305,17 @@ OptionsWindow::OptionsWindow(Profile *profile, ThemeLoader *themeLoader, QWidget
 	ui->comboTagsPosition->setCurrentIndex(positions.indexOf(settings->value("tagsposition", "top").toString()));
 	ui->spinPreload->setValue(settings->value("preload", 0).toInt());
 	ui->spinSlideshow->setValue(settings->value("slideshow", 0).toInt());
+
+	settings->beginGroup("Main/Shortcuts");
+		ui->keyMainQuit->setKeySequence(settings->value("keyMainQuit", QKeySequence(Qt::CTRL + Qt::Key_Q)).toString());
+		ui->keyMainFocusSearch->setKeySequence(settings->value("keyMainFocusSearch", QKeySequence(Qt::Key_S)).toString());
+		ui->keyMainCloseTab->setKeySequence(settings->value("keyMainCloseTab", QKeySequence(Qt::CTRL + Qt::Key_W)).toString());
+		ui->keyMainNewTab->setKeySequence(settings->value("keyMainNewTab", QKeySequence(Qt::CTRL + Qt::Key_T)).toString());
+		ui->keyMainPrevTab->setKeySequence(settings->value("keyMainPrevTab", QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_Tab)).toString());
+		ui->keyMainNextTab->setKeySequence(settings->value("keyMainNextTab", QKeySequence(Qt::CTRL + Qt::Key_Tab)).toString());
+		ui->keyMainBrowseSave->setKeySequence(settings->value("keyMainBrowseSave", QKeySequence(Qt::CTRL + Qt::Key_O)).toString());
+	settings->endGroup();
+
 	ui->checkResultsScrollArea->setChecked(settings->value("resultsScrollArea", true).toBool());
 	ui->checkResultsFixedWidthLayout->setChecked(settings->value("resultsFixedWidthLayout", false).toBool());
 	ui->checkImageCloseMiddleClick->setChecked(settings->value("imageCloseMiddleClick", true).toBool());
@@ -326,6 +337,23 @@ OptionsWindow::OptionsWindow(Profile *profile, ThemeLoader *themeLoader, QWidget
 	ui->comboImagePositionVideoV->setCurrentIndex(positionsV.indexOf(settings->value("imagePositionVideoV", "center").toString()));
 	ui->comboImagePositionVideoH->setCurrentIndex(positionsH.indexOf(settings->value("imagePositionVideoH", "left").toString()));
 	ui->lineImageBackgroundColor->setText(settings->value("imageBackgroundColor", QString()).toString());
+
+	settings->beginGroup("Zoom/Shortcuts");
+		ui->keyViewerQuit->setKeySequence(settings->value("keyViewerQuit", QKeySequence(Qt::Key_Q)).toString());
+		ui->keyViewerPrev->setKeySequence(settings->value("keyViewerPrev", QKeySequence(Qt::Key_Left)).toString());
+		ui->keyViewerNext->setKeySequence(settings->value("keyViewerNext", QKeySequence(Qt::Key_Right)).toString());
+		ui->keyViewerDetails->setKeySequence(settings->value("keyViewerDetails", QKeySequence(Qt::Key_D)).toString());
+		ui->keyViewerSaveAs->setKeySequence(settings->value("keyViewerSaveAs", QKeySequence(Qt::SHIFT + Qt::Key_S)).toString());
+		ui->keyViewerSave->setKeySequence(settings->value("keyViewerSave", QKeySequence(Qt::Key_S)).toString());
+		ui->keyViewerSaveNQuit->setKeySequence(settings->value("keyViewerSaveNQuit", QKeySequence(Qt::Key_W)).toString());
+		ui->keyViewerOpen->setKeySequence(settings->value("keyViewerOpen", QKeySequence(Qt::Key_T)).toString());
+		ui->keyViewerSaveFav->setKeySequence(settings->value("keyViewerSaveFav", QKeySequence(Qt::ALT + Qt::Key_S)).toString());
+		ui->keyViewerSaveNQuitFav->setKeySequence(settings->value("keyViewerSaveNQuitFav", QKeySequence(Qt::ALT + Qt::Key_W)).toString());
+		ui->keyViewerOpenFav->setKeySequence(settings->value("keyViewerOpenFav", QKeySequence(Qt::ALT + Qt::Key_T)).toString());
+		ui->keyViewerToggleSlideshow->setKeySequence(settings->value("keyViewerToggleSlideshow", QKeySequence(Qt::Key_Space)).toString());
+		ui->keyViewerToggleFullscreen->setKeySequence(settings->value("keyViewerToggleFullscreen", QKeySequence(Qt::Key_F)).toString());
+		ui->keyViewerDataToClipboard->setKeySequence(settings->value("keyViewerDataToClipboard", QKeySequence(Qt::CTRL + Qt::Key_C)).toString());
+	settings->endGroup();
 
 	settings->beginGroup("Coloring");
 		settings->beginGroup("Colors");
@@ -1124,6 +1152,17 @@ void OptionsWindow::save()
 	settings->setValue("tagsposition", positions.at(ui->comboTagsPosition->currentIndex()));
 	settings->setValue("preload", ui->spinPreload->value());
 	settings->setValue("slideshow", ui->spinSlideshow->value());
+
+	settings->beginGroup("Main/Shortcuts");
+		settings->setValue("keyMainQuit", ui->keyMainQuit->keySequence().toString());
+		settings->setValue("keyMainFocusSearch", ui->keyMainFocusSearch->keySequence().toString());
+		settings->setValue("keyMainCloseTab", ui->keyMainCloseTab->keySequence().toString());
+		settings->setValue("keyMainNewTab", ui->keyMainNewTab->keySequence().toString());
+		settings->setValue("keyMainPrevTab", ui->keyMainPrevTab->keySequence().toString());
+		settings->setValue("keyMainNextTab", ui->keyMainNextTab->keySequence().toString());
+		settings->setValue("keyMainBrowseSave", ui->keyMainBrowseSave->keySequence().toString());
+	settings->endGroup();
+
 	settings->setValue("resultsScrollArea", ui->checkResultsScrollArea->isChecked());
 	settings->setValue("resultsFixedWidthLayout", ui->checkResultsFixedWidthLayout->isChecked());
 	settings->setValue("imageCloseMiddleClick", ui->checkImageCloseMiddleClick->isChecked());
@@ -1145,6 +1184,23 @@ void OptionsWindow::save()
 	settings->setValue("imagePositionVideoV", positionsV.at(ui->comboImagePositionVideoV->currentIndex()));
 	settings->setValue("imagePositionVideoH", positionsH.at(ui->comboImagePositionVideoH->currentIndex()));
 	settings->setValue("imageBackgroundColor", ui->lineImageBackgroundColor->text());
+
+	settings->beginGroup("Zoom/Shortcuts");
+		settings->setValue("keyViewerQuit", ui->keyViewerQuit->keySequence().toString());
+		settings->setValue("keyViewerPrev", ui->keyViewerPrev->keySequence().toString());
+		settings->setValue("keyViewerNext", ui->keyViewerNext->keySequence().toString());
+		settings->setValue("keyViewerDetails", ui->keyViewerDetails->keySequence().toString());
+		settings->setValue("keyViewerSaveAs", ui->keyViewerSaveAs->keySequence().toString());
+		settings->setValue("keyViewerSave", ui->keyViewerSave->keySequence().toString());
+		settings->setValue("keyViewerSaveNQuit", ui->keyViewerSaveNQuit->keySequence().toString());
+		settings->setValue("keyViewerOpen", ui->keyViewerOpen->keySequence().toString());
+		settings->setValue("keyViewerSaveFav", ui->keyViewerSaveFav->keySequence().toString());
+		settings->setValue("keyViewerSaveNQuitFav", ui->keyViewerSaveNQuitFav->keySequence().toString());
+		settings->setValue("keyViewerOpenFav", ui->keyViewerOpenFav->keySequence().toString());
+		settings->setValue("keyViewerToggleSlideshow", ui->keyViewerToggleSlideshow->keySequence().toString());
+		settings->setValue("keyViewerToggleFullscreen", ui->keyViewerToggleFullscreen->keySequence().toString());
+		settings->setValue("keyViewerDataToClipboard", ui->keyViewerDataToClipboard->keySequence().toString());
+	settings->endGroup();
 
 	settings->beginGroup("Coloring");
 		settings->beginGroup("Colors");

--- a/src/gui/src/settings/options-window.ui
+++ b/src/gui/src/settings/options-window.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>666</width>
-    <height>516</height>
+    <height>528</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -110,8 +110,18 @@
        </property>
        <item>
         <property name="text">
-         <string>Search results</string>
+         <string>Main window</string>
         </property>
+        <item>
+         <property name="text">
+          <string>Search results</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Shortcuts</string>
+         </property>
+        </item>
        </item>
        <item>
         <property name="text">
@@ -1044,8 +1054,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>363</width>
-             <height>426</height>
+             <width>68</width>
+             <height>16</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="scrollAreaWidgetLayout">
@@ -1488,7 +1498,10 @@
         </item>
        </layout>
       </widget>
-      <widget class="QWidget" name="pageInterfaceSearchResults">
+      <widget class="QWidget" name="pageInterfaceMainWindow">
+       <layout class="QVBoxLayout" name="verticalLayout_11"/>
+      </widget>
+      <widget class="QWidget" name="pageInterfaceMainWindowSearchResults">
        <layout class="QFormLayout" name="formLayout_24">
         <item row="0" column="0" colspan="2">
          <widget class="QCheckBox" name="checkResultsScrollArea">
@@ -1615,6 +1628,141 @@
           <property name="wordWrap">
            <bool>true</bool>
           </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="pageInterfaceMainWindowShortcuts">
+       <layout class="QVBoxLayout" name="verticalLayout_9">
+        <item>
+         <widget class="QScrollArea" name="scrollArea_3">
+          <property name="widgetResizable">
+           <bool>true</bool>
+          </property>
+          <widget class="QWidget" name="scrollAreaWidgetContents_3">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>0</y>
+             <width>352</width>
+             <height>495</height>
+            </rect>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_10">
+            <item>
+             <widget class="QGroupBox" name="groupMainShortcutQuit">
+              <property name="title">
+               <string>Quit application</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_24">
+               <item>
+                <widget class="QKeySequenceEdit" name="keyMainQuit">
+                 <property name="keySequence">
+                  <string>Ctrl+Q</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupMainShortcutFocusSearch">
+              <property name="title">
+               <string>Focus search field</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_25">
+               <item>
+                <widget class="QKeySequenceEdit" name="keyMainFocusSearch">
+                 <property name="keySequence">
+                  <string>S</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupMainShortcutCloseTab">
+              <property name="title">
+               <string>Close tab</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_22">
+               <item>
+                <widget class="QKeySequenceEdit" name="keyMainCloseTab">
+                 <property name="keySequence">
+                  <string>Ctrl+W</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupMainShortcutNewTab">
+              <property name="title">
+               <string>New tab</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_23">
+               <item>
+                <widget class="QKeySequenceEdit" name="keyMainNewTab">
+                 <property name="keySequence">
+                  <string>Ctrl+T</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupMainShortcutPreviousTab">
+              <property name="title">
+               <string>Open previous tab</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_27">
+               <item>
+                <widget class="QKeySequenceEdit" name="keyMainPrevTab">
+                 <property name="keySequence">
+                  <string>Ctrl+Shift+Tab</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupMainShortcutNextTab">
+              <property name="title">
+               <string>Open next tab</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_26">
+               <item>
+                <widget class="QKeySequenceEdit" name="keyMainNextTab">
+                 <property name="keySequence">
+                  <string>Ctrl+Tab</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupMainShortcutBrowseSave">
+              <property name="title">
+               <string>Call external application to browse save directory</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_28">
+               <item>
+                <widget class="QKeySequenceEdit" name="keyMainBrowseSave">
+                 <property name="keySequence">
+                  <string>Ctrl+O</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+           </layout>
+          </widget>
          </widget>
         </item>
        </layout>
@@ -1978,7 +2126,7 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>417</width>
+             <width>352</width>
              <height>978</height>
             </rect>
            </property>

--- a/src/gui/src/settings/options-window.ui
+++ b/src/gui/src/settings/options-window.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>666</width>
-    <height>528</height>
+    <width>922</width>
+    <height>641</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -1054,8 +1054,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>68</width>
-             <height>16</height>
+             <width>521</width>
+             <height>547</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="scrollAreaWidgetLayout">
@@ -1644,17 +1644,32 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>352</width>
-             <height>495</height>
+             <width>519</width>
+             <height>573</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_10">
             <item>
              <widget class="QGroupBox" name="groupMainShortcutQuit">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="title">
                <string>Quit application</string>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_24">
+               <property name="spacing">
+                <number>6</number>
+               </property>
+               <property name="topMargin">
+                <number>3</number>
+               </property>
+               <property name="bottomMargin">
+                <number>3</number>
+               </property>
                <item>
                 <widget class="QKeySequenceEdit" name="keyMainQuit">
                  <property name="keySequence">
@@ -1667,10 +1682,22 @@
             </item>
             <item>
              <widget class="QGroupBox" name="groupMainShortcutFocusSearch">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="title">
                <string>Focus search field</string>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_25">
+               <property name="topMargin">
+                <number>3</number>
+               </property>
+               <property name="bottomMargin">
+                <number>3</number>
+               </property>
                <item>
                 <widget class="QKeySequenceEdit" name="keyMainFocusSearch">
                  <property name="keySequence">
@@ -1683,10 +1710,22 @@
             </item>
             <item>
              <widget class="QGroupBox" name="groupMainShortcutCloseTab">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="title">
                <string>Close tab</string>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_22">
+               <property name="topMargin">
+                <number>3</number>
+               </property>
+               <property name="bottomMargin">
+                <number>3</number>
+               </property>
                <item>
                 <widget class="QKeySequenceEdit" name="keyMainCloseTab">
                  <property name="keySequence">
@@ -1699,10 +1738,22 @@
             </item>
             <item>
              <widget class="QGroupBox" name="groupMainShortcutNewTab">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="title">
                <string>New tab</string>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_23">
+               <property name="topMargin">
+                <number>3</number>
+               </property>
+               <property name="bottomMargin">
+                <number>3</number>
+               </property>
                <item>
                 <widget class="QKeySequenceEdit" name="keyMainNewTab">
                  <property name="keySequence">
@@ -1715,10 +1766,22 @@
             </item>
             <item>
              <widget class="QGroupBox" name="groupMainShortcutPreviousTab">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="title">
                <string>Open previous tab</string>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_27">
+               <property name="topMargin">
+                <number>3</number>
+               </property>
+               <property name="bottomMargin">
+                <number>3</number>
+               </property>
                <item>
                 <widget class="QKeySequenceEdit" name="keyMainPrevTab">
                  <property name="keySequence">
@@ -1731,10 +1794,22 @@
             </item>
             <item>
              <widget class="QGroupBox" name="groupMainShortcutNextTab">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="title">
                <string>Open next tab</string>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_26">
+               <property name="topMargin">
+                <number>3</number>
+               </property>
+               <property name="bottomMargin">
+                <number>3</number>
+               </property>
                <item>
                 <widget class="QKeySequenceEdit" name="keyMainNextTab">
                  <property name="keySequence">
@@ -1747,10 +1822,22 @@
             </item>
             <item>
              <widget class="QGroupBox" name="groupMainShortcutBrowseSave">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="title">
                <string>Call external application to browse save directory</string>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_28">
+               <property name="topMargin">
+                <number>3</number>
+               </property>
+               <property name="bottomMargin">
+                <number>3</number>
+               </property>
                <item>
                 <widget class="QKeySequenceEdit" name="keyMainBrowseSave">
                  <property name="keySequence">
@@ -1760,6 +1847,19 @@
                </item>
               </layout>
              </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_5">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
             </item>
            </layout>
           </widget>
@@ -2126,17 +2226,29 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>352</width>
-             <height>978</height>
+             <width>505</width>
+             <height>810</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_8">
             <item>
              <widget class="QGroupBox" name="groupViewerShortcutQuit">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="title">
                <string>Close</string>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_18">
+               <property name="topMargin">
+                <number>3</number>
+               </property>
+               <property name="bottomMargin">
+                <number>3</number>
+               </property>
                <item>
                 <widget class="QKeySequenceEdit" name="keyViewerQuit">
                  <property name="keySequence">
@@ -2149,10 +2261,22 @@
             </item>
             <item>
              <widget class="QGroupBox" name="groupViewerShortcutPrev">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="title">
                <string>Prev</string>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_3">
+               <property name="topMargin">
+                <number>3</number>
+               </property>
+               <property name="bottomMargin">
+                <number>3</number>
+               </property>
                <item>
                 <widget class="QKeySequenceEdit" name="keyViewerPrev">
                  <property name="keySequence">
@@ -2165,10 +2289,22 @@
             </item>
             <item>
              <widget class="QGroupBox" name="groupViewerShortcutNext">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="title">
                <string>Next</string>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_4">
+               <property name="topMargin">
+                <number>3</number>
+               </property>
+               <property name="bottomMargin">
+                <number>3</number>
+               </property>
                <item>
                 <widget class="QKeySequenceEdit" name="keyViewerNext">
                  <property name="keySequence">
@@ -2181,10 +2317,22 @@
             </item>
             <item>
              <widget class="QGroupBox" name="groupViewerShortcutDetails">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="title">
                <string>Details</string>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_5">
+               <property name="topMargin">
+                <number>3</number>
+               </property>
+               <property name="bottomMargin">
+                <number>3</number>
+               </property>
                <item>
                 <widget class="QKeySequenceEdit" name="keyViewerDetails">
                  <property name="keySequence">
@@ -2197,10 +2345,22 @@
             </item>
             <item>
              <widget class="QGroupBox" name="groupViewerShortcutSaveAs">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="title">
                <string>Save as...</string>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_6">
+               <property name="topMargin">
+                <number>3</number>
+               </property>
+               <property name="bottomMargin">
+                <number>3</number>
+               </property>
                <item>
                 <widget class="QKeySequenceEdit" name="keyViewerSaveAs">
                  <property name="keySequence">
@@ -2213,10 +2373,22 @@
             </item>
             <item>
              <widget class="QGroupBox" name="groupViewerShortcutSave">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="title">
                <string>Save</string>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_7">
+               <property name="topMargin">
+                <number>3</number>
+               </property>
+               <property name="bottomMargin">
+                <number>3</number>
+               </property>
                <item>
                 <widget class="QKeySequenceEdit" name="keyViewerSave">
                  <property name="keySequence">
@@ -2229,10 +2401,22 @@
             </item>
             <item>
              <widget class="QGroupBox" name="groupViewerShortcutSaveNQuit">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="title">
                <string>Save and close</string>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_8">
+               <property name="topMargin">
+                <number>3</number>
+               </property>
+               <property name="bottomMargin">
+                <number>3</number>
+               </property>
                <item>
                 <widget class="QKeySequenceEdit" name="keyViewerSaveNQuit">
                  <property name="keySequence">
@@ -2245,10 +2429,22 @@
             </item>
             <item>
              <widget class="QGroupBox" name="groupViewerShortcutOpen">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="title">
                <string>Destination folder</string>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_10">
+               <property name="topMargin">
+                <number>3</number>
+               </property>
+               <property name="bottomMargin">
+                <number>3</number>
+               </property>
                <item>
                 <widget class="QKeySequenceEdit" name="keyViewerOpen">
                  <property name="keySequence">
@@ -2261,10 +2457,22 @@
             </item>
             <item>
              <widget class="QGroupBox" name="groupViewerShortcutSaveFav">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="title">
                <string>Save (fav)</string>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_11">
+               <property name="topMargin">
+                <number>3</number>
+               </property>
+               <property name="bottomMargin">
+                <number>3</number>
+               </property>
                <item>
                 <widget class="QKeySequenceEdit" name="keyViewerSaveFav">
                  <property name="keySequence">
@@ -2277,10 +2485,22 @@
             </item>
             <item>
              <widget class="QGroupBox" name="groupViewerShortcutSaveNQuitFav">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="title">
                <string>Save and close (fav)</string>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_12">
+               <property name="topMargin">
+                <number>3</number>
+               </property>
+               <property name="bottomMargin">
+                <number>3</number>
+               </property>
                <item>
                 <widget class="QKeySequenceEdit" name="keyViewerSaveNQuitFav">
                  <property name="keySequence">
@@ -2293,10 +2513,22 @@
             </item>
             <item>
              <widget class="QGroupBox" name="groupViewerShortcutOpenFav">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="title">
                <string>Destination folder (fav)</string>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_17">
+               <property name="topMargin">
+                <number>3</number>
+               </property>
+               <property name="bottomMargin">
+                <number>3</number>
+               </property>
                <item>
                 <widget class="QKeySequenceEdit" name="keyViewerOpenFav">
                  <property name="keySequence">
@@ -2309,10 +2541,22 @@
             </item>
             <item>
              <widget class="QGroupBox" name="groupViewerShortcutToggleFullscreen">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="title">
                <string>Toggle full-screen</string>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_19">
+               <property name="topMargin">
+                <number>3</number>
+               </property>
+               <property name="bottomMargin">
+                <number>3</number>
+               </property>
                <item>
                 <widget class="QKeySequenceEdit" name="keyViewerToggleFullscreen">
                  <property name="keySequence">
@@ -2325,10 +2569,22 @@
             </item>
             <item>
              <widget class="QGroupBox" name="groupViewerShortcutToggleSlideshow">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="title">
                <string>Toggle slideshow</string>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_21">
+               <property name="topMargin">
+                <number>3</number>
+               </property>
+               <property name="bottomMargin">
+                <number>3</number>
+               </property>
                <item>
                 <widget class="QKeySequenceEdit" name="keyViewerToggleSlideshow">
                  <property name="keySequence">
@@ -2341,10 +2597,22 @@
             </item>
             <item>
              <widget class="QGroupBox" name="groupViewerShortcutDataToClipboard">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="title">
                <string>Copy raw media data to clipboard</string>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_20">
+               <property name="topMargin">
+                <number>3</number>
+               </property>
+               <property name="bottomMargin">
+                <number>3</number>
+               </property>
                <item>
                 <widget class="QKeySequenceEdit" name="keyViewerDataToClipboard">
                  <property name="keySequence">

--- a/src/gui/src/settings/options-window.ui
+++ b/src/gui/src/settings/options-window.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>922</width>
-    <height>641</height>
+    <width>666</width>
+    <height>528</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -1054,8 +1054,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>521</width>
-             <height>547</height>
+             <width>363</width>
+             <height>438</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="scrollAreaWidgetLayout">
@@ -1634,8 +1634,23 @@
       </widget>
       <widget class="QWidget" name="pageInterfaceMainWindowShortcuts">
        <layout class="QVBoxLayout" name="verticalLayout_9">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
         <item>
          <widget class="QScrollArea" name="scrollArea_3">
+          <property name="frameShape">
+           <enum>QFrame::NoFrame</enum>
+          </property>
           <property name="widgetResizable">
            <bool>true</bool>
           </property>
@@ -1644,8 +1659,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>519</width>
-             <height>573</height>
+             <width>381</width>
+             <height>483</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -1855,8 +1870,8 @@
               </property>
               <property name="sizeHint" stdset="0">
                <size>
-                <width>20</width>
-                <height>40</height>
+                <width>0</width>
+                <height>0</height>
                </size>
               </property>
              </spacer>
@@ -2216,8 +2231,23 @@
       </widget>
       <widget class="QWidget" name="pageInterfaceImageWindowShortcuts">
        <layout class="QVBoxLayout" name="verticalLayout_7">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
         <item>
          <widget class="QScrollArea" name="scrollArea_2">
+          <property name="frameShape">
+           <enum>QFrame::NoFrame</enum>
+          </property>
           <property name="widgetResizable">
            <bool>true</bool>
           </property>
@@ -2226,7 +2256,7 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>505</width>
+             <width>367</width>
              <height>810</height>
             </rect>
            </property>

--- a/src/gui/src/settings/options-window.ui
+++ b/src/gui/src/settings/options-window.ui
@@ -117,6 +117,11 @@
         <property name="text">
          <string>Image window</string>
         </property>
+        <item>
+         <property name="text">
+          <string>Shortcuts</string>
+         </property>
+        </item>
        </item>
        <item>
         <property name="text">
@@ -1957,6 +1962,253 @@
           <property name="checked">
            <bool>true</bool>
           </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="pageInterfaceImageWindowShortcuts">
+       <layout class="QVBoxLayout" name="verticalLayout_7">
+        <item>
+         <widget class="QScrollArea" name="scrollArea_2">
+          <property name="widgetResizable">
+           <bool>true</bool>
+          </property>
+          <widget class="QWidget" name="scrollAreaWidgetContents_2">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>0</y>
+             <width>417</width>
+             <height>978</height>
+            </rect>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_8">
+            <item>
+             <widget class="QGroupBox" name="groupViewerShortcutQuit">
+              <property name="title">
+               <string>Close</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_18">
+               <item>
+                <widget class="QKeySequenceEdit" name="keyViewerQuit">
+                 <property name="keySequence">
+                  <string>Esc</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupViewerShortcutPrev">
+              <property name="title">
+               <string>Prev</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_3">
+               <item>
+                <widget class="QKeySequenceEdit" name="keyViewerPrev">
+                 <property name="keySequence">
+                  <string>Left</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupViewerShortcutNext">
+              <property name="title">
+               <string>Next</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_4">
+               <item>
+                <widget class="QKeySequenceEdit" name="keyViewerNext">
+                 <property name="keySequence">
+                  <string>Right</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupViewerShortcutDetails">
+              <property name="title">
+               <string>Details</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_5">
+               <item>
+                <widget class="QKeySequenceEdit" name="keyViewerDetails">
+                 <property name="keySequence">
+                  <string>D</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupViewerShortcutSaveAs">
+              <property name="title">
+               <string>Save as...</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_6">
+               <item>
+                <widget class="QKeySequenceEdit" name="keyViewerSaveAs">
+                 <property name="keySequence">
+                  <string>Shift+S</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupViewerShortcutSave">
+              <property name="title">
+               <string>Save</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_7">
+               <item>
+                <widget class="QKeySequenceEdit" name="keyViewerSave">
+                 <property name="keySequence">
+                  <string>S</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupViewerShortcutSaveNQuit">
+              <property name="title">
+               <string>Save and close</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_8">
+               <item>
+                <widget class="QKeySequenceEdit" name="keyViewerSaveNQuit">
+                 <property name="keySequence">
+                  <string>W</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupViewerShortcutOpen">
+              <property name="title">
+               <string>Destination folder</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_10">
+               <item>
+                <widget class="QKeySequenceEdit" name="keyViewerOpen">
+                 <property name="keySequence">
+                  <string>O</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupViewerShortcutSaveFav">
+              <property name="title">
+               <string>Save (fav)</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_11">
+               <item>
+                <widget class="QKeySequenceEdit" name="keyViewerSaveFav">
+                 <property name="keySequence">
+                  <string>Alt+S</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupViewerShortcutSaveNQuitFav">
+              <property name="title">
+               <string>Save and close (fav)</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_12">
+               <item>
+                <widget class="QKeySequenceEdit" name="keyViewerSaveNQuitFav">
+                 <property name="keySequence">
+                  <string>Alt+W</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupViewerShortcutOpenFav">
+              <property name="title">
+               <string>Destination folder (fav)</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_17">
+               <item>
+                <widget class="QKeySequenceEdit" name="keyViewerOpenFav">
+                 <property name="keySequence">
+                  <string>Alt+O</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupViewerShortcutToggleFullscreen">
+              <property name="title">
+               <string>Toggle full-screen</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_19">
+               <item>
+                <widget class="QKeySequenceEdit" name="keyViewerToggleFullscreen">
+                 <property name="keySequence">
+                  <string>F11</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupViewerShortcutToggleSlideshow">
+              <property name="title">
+               <string>Toggle slideshow</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_21">
+               <item>
+                <widget class="QKeySequenceEdit" name="keyViewerToggleSlideshow">
+                 <property name="keySequence">
+                  <string>Space</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupViewerShortcutDataToClipboard">
+              <property name="title">
+               <string>Copy raw media data to clipboard</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_20">
+               <item>
+                <widget class="QKeySequenceEdit" name="keyViewerDataToClipboard">
+                 <property name="keySequence">
+                  <string>C</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+           </layout>
+          </widget>
          </widget>
         </item>
        </layout>

--- a/src/gui/src/viewer/zoom-window.cpp
+++ b/src/gui/src/viewer/zoom-window.cpp
@@ -78,14 +78,14 @@ ZoomWindow::ZoomWindow(QList<QSharedPointer<Image>> images, const QSharedPointer
 			connect(save, SIGNAL(activated()), this, SLOT(saveImage()));
 		QShortcut *saveNQuit = new QShortcut(m_settings->value("keyViewerSaveNQuit", QKeySequence(Qt::Key_W)).toString(), this);
 			connect(saveNQuit, SIGNAL(activated()), this, SLOT(saveNQuit()));
-		QShortcut *open = new QShortcut(m_settings->value("keyViewerOpen", QKeySequence(Qt::Key_T)).toString(), this);
+		QShortcut *open = new QShortcut(m_settings->value("keyViewerOpen", QKeySequence(Qt::Key_B)).toString(), this);
 			connect(open, SIGNAL(activated()), this, SLOT(openSaveDirFav()));
 
 		QShortcut *saveFav = new QShortcut(m_settings->value("keyViewerSaveFav", QKeySequence(Qt::ALT + Qt::Key_S)).toString(), this);
 			connect(saveFav, SIGNAL(activated()), this, SLOT(saveImageFav()));
 		QShortcut *saveNQuitFav = new QShortcut(m_settings->value("keyViewerSaveNQuitFav", QKeySequence(Qt::ALT + Qt::Key_W)).toString(), this);
 			connect(saveNQuitFav, SIGNAL(activated()), this, SLOT(saveNQuitFav()));
-		QShortcut *openFav = new QShortcut(m_settings->value("keyViewerOpenFav", QKeySequence(Qt::ALT + Qt::Key_T)).toString(), this);
+		QShortcut *openFav = new QShortcut(m_settings->value("keyViewerOpenFav", QKeySequence(Qt::ALT + Qt::Key_B)).toString(), this);
 			connect(openFav, SIGNAL(activated()), this, SLOT(openSaveDirFav()));
 
 		QShortcut *toggleSlideshow = new QShortcut(m_settings->value("keyViewerToggleSlideshow", QKeySequence(Qt::Key_Space)).toString(), this);

--- a/src/gui/src/viewer/zoom-window.cpp
+++ b/src/gui/src/viewer/zoom-window.cpp
@@ -78,14 +78,14 @@ ZoomWindow::ZoomWindow(QList<QSharedPointer<Image>> images, const QSharedPointer
 			connect(save, SIGNAL(activated()), this, SLOT(saveImage()));
 		QShortcut *saveNQuit = new QShortcut(getKeySequence(m_settings, "keySaveNQuit", Qt::CTRL + Qt::Key_W), this);
 			connect(saveNQuit, SIGNAL(activated()), this, SLOT(saveNQuit()));
-		QShortcut *open = new QShortcut(getKeySequence(m_settings, "keyOpen", Qt::CTRL + Qt::Key_B), this);
+		QShortcut *open = new QShortcut(getKeySequence(m_settings, "keyOpen", Qt::CTRL + Qt::Key_O), this);
 			connect(open, SIGNAL(activated()), this, SLOT(openSaveDirFav()));
 
 		QShortcut *saveFav = new QShortcut(getKeySequence(m_settings, "keySaveFav", Qt::CTRL + Qt::ALT + Qt::Key_S), this);
 			connect(saveFav, SIGNAL(activated()), this, SLOT(saveImageFav()));
 		QShortcut *saveNQuitFav = new QShortcut(getKeySequence(m_settings, "keySaveNQuitFav", Qt::CTRL + Qt::ALT + Qt::Key_W), this);
 			connect(saveNQuitFav, SIGNAL(activated()), this, SLOT(saveNQuitFav()));
-		QShortcut *openFav = new QShortcut(getKeySequence(m_settings, "keyOpenFav", Qt::CTRL + Qt::ALT + Qt::Key_B), this);
+		QShortcut *openFav = new QShortcut(getKeySequence(m_settings, "keyOpenFav", Qt::CTRL + Qt::ALT + Qt::Key_O), this);
 			connect(openFav, SIGNAL(activated()), this, SLOT(openSaveDirFav()));
 
 		QShortcut *toggleFullscreen = new QShortcut(getKeySequence(m_settings, "keyToggleFullscreen", QKeySequence::FullScreen, Qt::Key_F11), this);

--- a/src/gui/src/viewer/zoom-window.cpp
+++ b/src/gui/src/viewer/zoom-window.cpp
@@ -61,20 +61,40 @@ ZoomWindow::ZoomWindow(QList<QSharedPointer<Image>> images, const QSharedPointer
 	ui->buttonPlus->setChecked(m_settings->value("Zoom/plus", false).toBool());
 	ui->progressBarDownload->hide();
 
-	QShortcut *escape = new QShortcut(QKeySequence(Qt::Key_Escape), this);
-		connect(escape, &QShortcut::activated, this, &ZoomWindow::close);
-	QShortcut *save = new QShortcut(QKeySequence::Save, this);
-		connect(save, SIGNAL(activated()), this, SLOT(saveImage()));
-	QShortcut *saveAs = new QShortcut(QKeySequence::SaveAs, this);
-		connect(saveAs, &QShortcut::activated, this, &ZoomWindow::saveImageAs);
-	QShortcut *arrowNext = new QShortcut(QKeySequence(Qt::Key_Right), this);
-		connect(arrowNext, &QShortcut::activated, this, &ZoomWindow::next);
-	QShortcut *arrowPrevious = new QShortcut(QKeySequence(Qt::Key_Left), this);
-		connect(arrowPrevious, &QShortcut::activated, this, &ZoomWindow::previous);
-	QShortcut *copyImageFile = new QShortcut(QKeySequence::Copy, this);
-		connect(copyImageFile, &QShortcut::activated, this, &ZoomWindow::copyImageDataToClipboard);
-	QShortcut *toggleFullscreen = new QShortcut(QKeySequence::FullScreen, this);
-		connect(toggleFullscreen, &QShortcut::activated, this, &ZoomWindow::toggleFullScreen);
+	m_settings->beginGroup("Zoom/Shortcuts");
+		QShortcut *quit = new QShortcut(m_settings->value("keyViewerQuit", QKeySequence(Qt::Key_Q)).toString(), this);
+			connect(quit, &QShortcut::activated, this, &ZoomWindow::close);
+		QShortcut *prev = new QShortcut(m_settings->value("keyViewerPrev", QKeySequence(Qt::Key_Left)).toString(), this);
+			connect(prev, &QShortcut::activated, this, &ZoomWindow::previous);
+		QShortcut *next = new QShortcut(m_settings->value("keyViewerNext", QKeySequence(Qt::Key_Right)).toString(), this);
+			connect(next, &QShortcut::activated, this, &ZoomWindow::next);
+
+		QShortcut *details = new QShortcut(m_settings->value("keyViewerDetails", QKeySequence(Qt::Key_D)).toString(), this);
+			connect(details, &QShortcut::activated, this, &ZoomWindow::showDetails);
+		QShortcut *saveAs = new QShortcut(m_settings->value("keyViewerSaveAs", QKeySequence(Qt::SHIFT + Qt::Key_S)).toString(), this);
+			connect(saveAs, &QShortcut::activated, this, &ZoomWindow::saveImageAs);
+
+		QShortcut *save = new QShortcut(m_settings->value("keyViewerSave", QKeySequence(Qt::Key_S)).toString(), this);
+			connect(save, SIGNAL(activated()), this, SLOT(saveImage()));
+		QShortcut *saveNQuit = new QShortcut(m_settings->value("keyViewerSaveNQuit", QKeySequence(Qt::Key_W)).toString(), this);
+			connect(saveNQuit, SIGNAL(activated()), this, SLOT(saveNQuit()));
+		QShortcut *open = new QShortcut(m_settings->value("keyViewerOpen", QKeySequence(Qt::Key_T)).toString(), this);
+			connect(open, SIGNAL(activated()), this, SLOT(openSaveDirFav()));
+
+		QShortcut *saveFav = new QShortcut(m_settings->value("keyViewerSaveFav", QKeySequence(Qt::ALT + Qt::Key_S)).toString(), this);
+			connect(saveFav, SIGNAL(activated()), this, SLOT(saveImageFav()));
+		QShortcut *saveNQuitFav = new QShortcut(m_settings->value("keyViewerSaveNQuitFav", QKeySequence(Qt::ALT + Qt::Key_W)).toString(), this);
+			connect(saveNQuitFav, SIGNAL(activated()), this, SLOT(saveNQuitFav()));
+		QShortcut *openFav = new QShortcut(m_settings->value("keyViewerOpenFav", QKeySequence(Qt::ALT + Qt::Key_T)).toString(), this);
+			connect(openFav, SIGNAL(activated()), this, SLOT(openSaveDirFav()));
+
+		QShortcut *toggleSlideshow = new QShortcut(m_settings->value("keyViewerToggleSlideshow", QKeySequence(Qt::Key_Space)).toString(), this);
+			connect(toggleSlideshow, &QShortcut::activated, this, &ZoomWindow::toggleSlideshow);
+		QShortcut *toggleFullscreen = new QShortcut(m_settings->value("keyViewerToggleFullscreen", QKeySequence(Qt::Key_F)).toString(), this);
+			connect(toggleFullscreen, &QShortcut::activated, this, &ZoomWindow::toggleFullScreen);
+		QShortcut *copyDataToClipboard = new QShortcut(m_settings->value("keyViewerDataToClipboard", QKeySequence(Qt::CTRL + Qt::Key_S)).toString(), this);
+			connect(copyDataToClipboard, &QShortcut::activated, this, &ZoomWindow::copyImageDataToClipboard);
+	m_settings->endGroup();
 
 	m_labelTagsLeft = new QAffiche(QVariant(), 0, QColor(), this);
 		m_labelTagsLeft->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -957,16 +977,19 @@ void ZoomWindow::fullScreen()
 	m_isFullscreen = true;
 	prepareNextSlide();
 
-	QShortcut *escape = new QShortcut(QKeySequence(Qt::Key_Escape), m_fullScreen);
-		connect(escape, SIGNAL(activated()), this, SLOT(unfullScreen()));
-	QShortcut *toggleFullscreen = new QShortcut(QKeySequence::FullScreen, m_fullScreen);
-		connect(toggleFullscreen, SIGNAL(activated()), this, SLOT(unfullScreen()));
-	QShortcut *arrowNext = new QShortcut(QKeySequence(Qt::Key_Right), m_fullScreen);
-		connect(arrowNext, &QShortcut::activated, this, &ZoomWindow::next);
-	QShortcut *arrowPrevious = new QShortcut(QKeySequence(Qt::Key_Left), m_fullScreen);
-		connect(arrowPrevious, &QShortcut::activated, this, &ZoomWindow::previous);
-	QShortcut *space = new QShortcut(QKeySequence(Qt::Key_Space), m_fullScreen);
-		connect(space, &QShortcut::activated, this, &ZoomWindow::toggleSlideshow);
+
+	m_settings->beginGroup("Zoom/Shortcuts");	// Could probably just use the variables already initialised when this ZoomWindow was constructed.
+		QShortcut *quit = new QShortcut(m_settings->value("keyViewerQuit", QKeySequence(Qt::Key_Q)).toString(), m_fullScreen);
+			connect(quit, &QShortcut::activated, this, &ZoomWindow::unfullScreen);
+		QShortcut *toggleFullscreen = new QShortcut(m_settings->value("keyViewerToggleFullscreen", QKeySequence(Qt::Key_F)).toString(), m_fullScreen);
+			connect(toggleFullscreen, &QShortcut::activated, this, &ZoomWindow::unfullScreen);
+		QShortcut *prev = new QShortcut(m_settings->value("keyViewerPrev", QKeySequence(Qt::Key_Left)).toString(), m_fullScreen);
+			connect(prev, &QShortcut::activated, this, &ZoomWindow::previous);
+		QShortcut *next = new QShortcut(m_settings->value("keyViewerNext", QKeySequence(Qt::Key_Right)).toString(), m_fullScreen);
+			connect(next, &QShortcut::activated, this, &ZoomWindow::next);
+		QShortcut *toggleSlideshow = new QShortcut(m_settings->value("keyViewerToggleSlideshow", QKeySequence(Qt::Key_Space)).toString(), m_fullScreen);
+			connect(toggleSlideshow, &QShortcut::activated, this, &ZoomWindow::toggleSlideshow);
+	m_settings->endGroup();
 
 	m_fullScreen->setFocus();
 }

--- a/src/gui/src/viewer/zoom-window.cpp
+++ b/src/gui/src/viewer/zoom-window.cpp
@@ -62,37 +62,35 @@ ZoomWindow::ZoomWindow(QList<QSharedPointer<Image>> images, const QSharedPointer
 	ui->progressBarDownload->hide();
 
 	m_settings->beginGroup("Zoom/Shortcuts");
-		QShortcut *quit = new QShortcut(m_settings->value("keyViewerQuit", QKeySequence(Qt::Key_Q)).toString(), this);
+		QShortcut *quit = new QShortcut(getKeySequence(m_settings, "keyViewerQuit", Qt::Key_Escape), this);
 			connect(quit, &QShortcut::activated, this, &ZoomWindow::close);
-		QShortcut *prev = new QShortcut(m_settings->value("keyViewerPrev", QKeySequence(Qt::Key_Left)).toString(), this);
+		QShortcut *prev = new QShortcut(getKeySequence(m_settings, "keyViewerPrev", Qt::Key_Left), this);
 			connect(prev, &QShortcut::activated, this, &ZoomWindow::previous);
-		QShortcut *next = new QShortcut(m_settings->value("keyViewerNext", QKeySequence(Qt::Key_Right)).toString(), this);
+		QShortcut *next = new QShortcut(getKeySequence(m_settings, "keyViewerNext", Qt::Key_Right), this);
 			connect(next, &QShortcut::activated, this, &ZoomWindow::next);
 
-		QShortcut *details = new QShortcut(m_settings->value("keyViewerDetails", QKeySequence(Qt::Key_D)).toString(), this);
+		QShortcut *details = new QShortcut(getKeySequence(m_settings, "keyViewerDetails", Qt::Key_D), this);
 			connect(details, &QShortcut::activated, this, &ZoomWindow::showDetails);
-		QShortcut *saveAs = new QShortcut(m_settings->value("keyViewerSaveAs", QKeySequence(Qt::SHIFT + Qt::Key_S)).toString(), this);
+		QShortcut *saveAs = new QShortcut(getKeySequence(m_settings, "keyViewerSaveAs", QKeySequence::SaveAs, Qt::CTRL + Qt::SHIFT + Qt::Key_S), this);
 			connect(saveAs, &QShortcut::activated, this, &ZoomWindow::saveImageAs);
 
-		QShortcut *save = new QShortcut(m_settings->value("keyViewerSave", QKeySequence(Qt::Key_S)).toString(), this);
+		QShortcut *save = new QShortcut(getKeySequence(m_settings, "keyViewerSave", QKeySequence::Save, Qt::CTRL + Qt::Key_S), this);
 			connect(save, SIGNAL(activated()), this, SLOT(saveImage()));
-		QShortcut *saveNQuit = new QShortcut(m_settings->value("keyViewerSaveNQuit", QKeySequence(Qt::Key_W)).toString(), this);
+		QShortcut *saveNQuit = new QShortcut(getKeySequence(m_settings, "keyViewerSaveNQuit", Qt::CTRL + Qt::Key_W), this);
 			connect(saveNQuit, SIGNAL(activated()), this, SLOT(saveNQuit()));
-		QShortcut *open = new QShortcut(m_settings->value("keyViewerOpen", QKeySequence(Qt::Key_B)).toString(), this);
+		QShortcut *open = new QShortcut(getKeySequence(m_settings, "keyViewerOpen", Qt::CTRL + Qt::Key_B), this);
 			connect(open, SIGNAL(activated()), this, SLOT(openSaveDirFav()));
 
-		QShortcut *saveFav = new QShortcut(m_settings->value("keyViewerSaveFav", QKeySequence(Qt::ALT + Qt::Key_S)).toString(), this);
+		QShortcut *saveFav = new QShortcut(getKeySequence(m_settings, "keyViewerSaveFav", Qt::CTRL + Qt::ALT + Qt::Key_S), this);
 			connect(saveFav, SIGNAL(activated()), this, SLOT(saveImageFav()));
-		QShortcut *saveNQuitFav = new QShortcut(m_settings->value("keyViewerSaveNQuitFav", QKeySequence(Qt::ALT + Qt::Key_W)).toString(), this);
+		QShortcut *saveNQuitFav = new QShortcut(getKeySequence(m_settings, "keyViewerSaveNQuitFav", Qt::CTRL + Qt::ALT + Qt::Key_W), this);
 			connect(saveNQuitFav, SIGNAL(activated()), this, SLOT(saveNQuitFav()));
-		QShortcut *openFav = new QShortcut(m_settings->value("keyViewerOpenFav", QKeySequence(Qt::ALT + Qt::Key_B)).toString(), this);
+		QShortcut *openFav = new QShortcut(getKeySequence(m_settings, "keyViewerOpenFav", Qt::CTRL + Qt::ALT + Qt::Key_B), this);
 			connect(openFav, SIGNAL(activated()), this, SLOT(openSaveDirFav()));
 
-		QShortcut *toggleSlideshow = new QShortcut(m_settings->value("keyViewerToggleSlideshow", QKeySequence(Qt::Key_Space)).toString(), this);
-			connect(toggleSlideshow, &QShortcut::activated, this, &ZoomWindow::toggleSlideshow);
-		QShortcut *toggleFullscreen = new QShortcut(m_settings->value("keyViewerToggleFullscreen", QKeySequence(Qt::Key_F)).toString(), this);
+		QShortcut *toggleFullscreen = new QShortcut(getKeySequence(m_settings, "keyViewerToggleFullscreen", QKeySequence::FullScreen, Qt::Key_F11), this);
 			connect(toggleFullscreen, &QShortcut::activated, this, &ZoomWindow::toggleFullScreen);
-		QShortcut *copyDataToClipboard = new QShortcut(m_settings->value("keyViewerDataToClipboard", QKeySequence(Qt::CTRL + Qt::Key_S)).toString(), this);
+		QShortcut *copyDataToClipboard = new QShortcut(getKeySequence(m_settings, "keyViewerDataToClipboard", QKeySequence::Copy, Qt::CTRL + Qt::Key_C), this);
 			connect(copyDataToClipboard, &QShortcut::activated, this, &ZoomWindow::copyImageDataToClipboard);
 	m_settings->endGroup();
 
@@ -977,17 +975,16 @@ void ZoomWindow::fullScreen()
 	m_isFullscreen = true;
 	prepareNextSlide();
 
-
 	m_settings->beginGroup("Zoom/Shortcuts");	// Could probably just use the variables already initialised when this ZoomWindow was constructed.
-		QShortcut *quit = new QShortcut(m_settings->value("keyViewerQuit", QKeySequence(Qt::Key_Q)).toString(), m_fullScreen);
+		QShortcut *quit = new QShortcut(getKeySequence(m_settings, "keyViewerQuit", Qt::Key_Escape), m_fullScreen);
 			connect(quit, &QShortcut::activated, this, &ZoomWindow::unfullScreen);
-		QShortcut *toggleFullscreen = new QShortcut(m_settings->value("keyViewerToggleFullscreen", QKeySequence(Qt::Key_F)).toString(), m_fullScreen);
+		QShortcut *toggleFullscreen = new QShortcut(getKeySequence(m_settings, "keyViewerToggleFullscreen", QKeySequence::FullScreen, Qt::Key_F11), m_fullScreen);
 			connect(toggleFullscreen, &QShortcut::activated, this, &ZoomWindow::unfullScreen);
-		QShortcut *prev = new QShortcut(m_settings->value("keyViewerPrev", QKeySequence(Qt::Key_Left)).toString(), m_fullScreen);
+		QShortcut *prev = new QShortcut(getKeySequence(m_settings, "keyViewerPrev", Qt::Key_Left), m_fullScreen);
 			connect(prev, &QShortcut::activated, this, &ZoomWindow::previous);
-		QShortcut *next = new QShortcut(m_settings->value("keyViewerNext", QKeySequence(Qt::Key_Right)).toString(), m_fullScreen);
+		QShortcut *next = new QShortcut(getKeySequence(m_settings, "keyViewerNext", Qt::Key_Right), m_fullScreen);
 			connect(next, &QShortcut::activated, this, &ZoomWindow::next);
-		QShortcut *toggleSlideshow = new QShortcut(m_settings->value("keyViewerToggleSlideshow", QKeySequence(Qt::Key_Space)).toString(), m_fullScreen);
+		QShortcut *toggleSlideshow = new QShortcut(getKeySequence(m_settings, "keyViewerToggleSlideshow", Qt::Key_Space), m_fullScreen);
 			connect(toggleSlideshow, &QShortcut::activated, this, &ZoomWindow::toggleSlideshow);
 	m_settings->endGroup();
 

--- a/src/gui/src/viewer/zoom-window.cpp
+++ b/src/gui/src/viewer/zoom-window.cpp
@@ -62,35 +62,35 @@ ZoomWindow::ZoomWindow(QList<QSharedPointer<Image>> images, const QSharedPointer
 	ui->progressBarDownload->hide();
 
 	m_settings->beginGroup("Zoom/Shortcuts");
-		QShortcut *quit = new QShortcut(getKeySequence(m_settings, "keyViewerQuit", Qt::Key_Escape), this);
+		QShortcut *quit = new QShortcut(getKeySequence(m_settings, "keyQuit", Qt::Key_Escape), this);
 			connect(quit, &QShortcut::activated, this, &ZoomWindow::close);
-		QShortcut *prev = new QShortcut(getKeySequence(m_settings, "keyViewerPrev", Qt::Key_Left), this);
+		QShortcut *prev = new QShortcut(getKeySequence(m_settings, "keyPrev", Qt::Key_Left), this);
 			connect(prev, &QShortcut::activated, this, &ZoomWindow::previous);
-		QShortcut *next = new QShortcut(getKeySequence(m_settings, "keyViewerNext", Qt::Key_Right), this);
+		QShortcut *next = new QShortcut(getKeySequence(m_settings, "keyNext", Qt::Key_Right), this);
 			connect(next, &QShortcut::activated, this, &ZoomWindow::next);
 
-		QShortcut *details = new QShortcut(getKeySequence(m_settings, "keyViewerDetails", Qt::Key_D), this);
+		QShortcut *details = new QShortcut(getKeySequence(m_settings, "keyDetails", Qt::Key_D), this);
 			connect(details, &QShortcut::activated, this, &ZoomWindow::showDetails);
-		QShortcut *saveAs = new QShortcut(getKeySequence(m_settings, "keyViewerSaveAs", QKeySequence::SaveAs, Qt::CTRL + Qt::SHIFT + Qt::Key_S), this);
+		QShortcut *saveAs = new QShortcut(getKeySequence(m_settings, "keySaveAs", QKeySequence::SaveAs, Qt::CTRL + Qt::SHIFT + Qt::Key_S), this);
 			connect(saveAs, &QShortcut::activated, this, &ZoomWindow::saveImageAs);
 
-		QShortcut *save = new QShortcut(getKeySequence(m_settings, "keyViewerSave", QKeySequence::Save, Qt::CTRL + Qt::Key_S), this);
+		QShortcut *save = new QShortcut(getKeySequence(m_settings, "keySave", QKeySequence::Save, Qt::CTRL + Qt::Key_S), this);
 			connect(save, SIGNAL(activated()), this, SLOT(saveImage()));
-		QShortcut *saveNQuit = new QShortcut(getKeySequence(m_settings, "keyViewerSaveNQuit", Qt::CTRL + Qt::Key_W), this);
+		QShortcut *saveNQuit = new QShortcut(getKeySequence(m_settings, "keySaveNQuit", Qt::CTRL + Qt::Key_W), this);
 			connect(saveNQuit, SIGNAL(activated()), this, SLOT(saveNQuit()));
-		QShortcut *open = new QShortcut(getKeySequence(m_settings, "keyViewerOpen", Qt::CTRL + Qt::Key_B), this);
+		QShortcut *open = new QShortcut(getKeySequence(m_settings, "keyOpen", Qt::CTRL + Qt::Key_B), this);
 			connect(open, SIGNAL(activated()), this, SLOT(openSaveDirFav()));
 
-		QShortcut *saveFav = new QShortcut(getKeySequence(m_settings, "keyViewerSaveFav", Qt::CTRL + Qt::ALT + Qt::Key_S), this);
+		QShortcut *saveFav = new QShortcut(getKeySequence(m_settings, "keySaveFav", Qt::CTRL + Qt::ALT + Qt::Key_S), this);
 			connect(saveFav, SIGNAL(activated()), this, SLOT(saveImageFav()));
-		QShortcut *saveNQuitFav = new QShortcut(getKeySequence(m_settings, "keyViewerSaveNQuitFav", Qt::CTRL + Qt::ALT + Qt::Key_W), this);
+		QShortcut *saveNQuitFav = new QShortcut(getKeySequence(m_settings, "keySaveNQuitFav", Qt::CTRL + Qt::ALT + Qt::Key_W), this);
 			connect(saveNQuitFav, SIGNAL(activated()), this, SLOT(saveNQuitFav()));
-		QShortcut *openFav = new QShortcut(getKeySequence(m_settings, "keyViewerOpenFav", Qt::CTRL + Qt::ALT + Qt::Key_B), this);
+		QShortcut *openFav = new QShortcut(getKeySequence(m_settings, "keyOpenFav", Qt::CTRL + Qt::ALT + Qt::Key_B), this);
 			connect(openFav, SIGNAL(activated()), this, SLOT(openSaveDirFav()));
 
-		QShortcut *toggleFullscreen = new QShortcut(getKeySequence(m_settings, "keyViewerToggleFullscreen", QKeySequence::FullScreen, Qt::Key_F11), this);
+		QShortcut *toggleFullscreen = new QShortcut(getKeySequence(m_settings, "keyToggleFullscreen", QKeySequence::FullScreen, Qt::Key_F11), this);
 			connect(toggleFullscreen, &QShortcut::activated, this, &ZoomWindow::toggleFullScreen);
-		QShortcut *copyDataToClipboard = new QShortcut(getKeySequence(m_settings, "keyViewerDataToClipboard", QKeySequence::Copy, Qt::CTRL + Qt::Key_C), this);
+		QShortcut *copyDataToClipboard = new QShortcut(getKeySequence(m_settings, "keyDataToClipboard", QKeySequence::Copy, Qt::CTRL + Qt::Key_C), this);
 			connect(copyDataToClipboard, &QShortcut::activated, this, &ZoomWindow::copyImageDataToClipboard);
 	m_settings->endGroup();
 
@@ -976,15 +976,15 @@ void ZoomWindow::fullScreen()
 	prepareNextSlide();
 
 	m_settings->beginGroup("Zoom/Shortcuts");	// Could probably just use the variables already initialised when this ZoomWindow was constructed.
-		QShortcut *quit = new QShortcut(getKeySequence(m_settings, "keyViewerQuit", Qt::Key_Escape), m_fullScreen);
+		QShortcut *quit = new QShortcut(getKeySequence(m_settings, "keyQuit", Qt::Key_Escape), m_fullScreen);
 			connect(quit, &QShortcut::activated, this, &ZoomWindow::unfullScreen);
-		QShortcut *toggleFullscreen = new QShortcut(getKeySequence(m_settings, "keyViewerToggleFullscreen", QKeySequence::FullScreen, Qt::Key_F11), m_fullScreen);
+		QShortcut *toggleFullscreen = new QShortcut(getKeySequence(m_settings, "keyToggleFullscreen", QKeySequence::FullScreen, Qt::Key_F11), m_fullScreen);
 			connect(toggleFullscreen, &QShortcut::activated, this, &ZoomWindow::unfullScreen);
-		QShortcut *prev = new QShortcut(getKeySequence(m_settings, "keyViewerPrev", Qt::Key_Left), m_fullScreen);
+		QShortcut *prev = new QShortcut(getKeySequence(m_settings, "keyPrev", Qt::Key_Left), m_fullScreen);
 			connect(prev, &QShortcut::activated, this, &ZoomWindow::previous);
-		QShortcut *next = new QShortcut(getKeySequence(m_settings, "keyViewerNext", Qt::Key_Right), m_fullScreen);
+		QShortcut *next = new QShortcut(getKeySequence(m_settings, "keyNext", Qt::Key_Right), m_fullScreen);
 			connect(next, &QShortcut::activated, this, &ZoomWindow::next);
-		QShortcut *toggleSlideshow = new QShortcut(getKeySequence(m_settings, "keyViewerToggleSlideshow", Qt::Key_Space), m_fullScreen);
+		QShortcut *toggleSlideshow = new QShortcut(getKeySequence(m_settings, "keyToggleSlideshow", Qt::Key_Space), m_fullScreen);
 			connect(toggleSlideshow, &QShortcut::activated, this, &ZoomWindow::toggleSlideshow);
 	m_settings->endGroup();
 

--- a/src/lib/src/functions.cpp
+++ b/src/lib/src/functions.cpp
@@ -1118,3 +1118,22 @@ bool createLink(const QString &from, const QString &to, const QString &type)
 	log(QStringLiteral("Invalid link type '%1'").arg(type), Logger::Error);
 	return false;
 }
+
+
+QKeySequence getKeySequence(QSettings *settings, const QString &key, QKeySequence::StandardKey standardDefault, const QKeySequence &altDefault)
+{
+	const auto standards = QKeySequence::keyBindings(standardDefault);
+	if (standards.isEmpty()) {
+		return getKeySequence(settings, key, altDefault);
+	}
+	return getKeySequence(settings, key, standards.first());
+}
+
+QKeySequence getKeySequence(QSettings *settings, const QString &key, const QKeySequence &def)
+{
+	QString val = settings->value(key).toString();
+	if (val.isEmpty()) {
+		return def;
+	}
+	return QKeySequence(val);
+}

--- a/src/lib/src/functions.h
+++ b/src/lib/src/functions.h
@@ -3,6 +3,7 @@
 
 #include <QMap>
 #include <QString>
+#include <QKeySequence>
 #include "backports/backports.h"
 
 
@@ -89,6 +90,9 @@ QUrl removeCacheBuster(QUrl url);
 
 bool canCreateLinkType(const QString &type, const QString &dir);
 bool createLink(const QString &from, const QString &to, const QString &type);
+
+QKeySequence getKeySequence(QSettings *settings, const QString &key, QKeySequence::StandardKey standardDefault, const QKeySequence &altDefault);
+QKeySequence getKeySequence(QSettings *settings, const QString &key, const QKeySequence &def);
 
 
 


### PR DESCRIPTION
I tried squashing the old script stuff. Hopefully this is slightly more convenient for you. I will probably make the other shortcuts customisable too. Does this seem like a good idea?

The reasons why I changed the default shortcuts, aside from my personal preference, are:

1. Not requiring multiple modifiers for basic actions.
2. Making all shortcuts (except left/right navigation) operable with left hand, so people don't have to move their hand off their mouse to use them.
3. Making the shortcuts more consistent/reliable (see below). These might be my fault somehow but replacing them fixed it so I don't think so.

QKeySequence::SaveAs is empty on my system. Unreliable.
QKeySequence::Save is 5 on my system for keyViewerSave. Doesn't make sense.
QKeySequence::Save is empty on my system for keyViewerSaveFav. Inconsistent with previous.
Qt::FullScreen is empty on my system.
QKeySequence::Copy is 9 on my system. Doesn't make sense.
