### PR TITLE
Adding shortcuts for miscellaneous dialogues.

### DIFF
--- a/src/gui/src/helpers.cpp
+++ b/src/gui/src/helpers.cpp
@@ -1,4 +1,5 @@
 #include "helpers.h"
+#include <QDialog>
 #include <QLayout>
 #include <QMessageBox>
 #if defined(Q_OS_WIN)
@@ -14,7 +15,10 @@
 	#include <QDesktopServices>
 	#include <QUrl>
 #endif
+#include <QSettings>
+#include <QShortcut>
 #include <QWidget>
+#include "functions.h"
 
 
 /**
@@ -79,4 +83,13 @@ void clearLayout(QLayout *layout)
 		}
 		delete item;
 	}
+}
+
+void setupDialogShortcuts(QDialog *dialog, QSettings *settings)
+{
+	auto *accept = new QShortcut(getKeySequence(settings, "keyAcceptDialog", Qt::CTRL + Qt::Key_Y), dialog);
+	QObject::connect(accept, &QShortcut::activated, dialog, &QDialog::accept);
+
+	auto *reject = new QShortcut(getKeySequence(settings, "keyDeclineDialog", Qt::CTRL + Qt::Key_N), dialog);
+	QObject::connect(reject, &QShortcut::activated, dialog, &QDialog::reject);
 }

--- a/src/gui/src/helpers.h
+++ b/src/gui/src/helpers.h
@@ -4,12 +4,15 @@
 #include <QString>
 
 
+class QDialog;
 class QLayout;
+class QSettings;
 class QWidget;
 
 
 void error(QWidget *parent, const QString &message);
 void showInGraphicalShell(const QString &path);
 void clearLayout(QLayout *layout);
+void setupDialogShortcuts(QDialog *dialog, QSettings *settings);
 
 #endif // HELPERS_H

--- a/src/gui/src/main-window.cpp
+++ b/src/gui/src/main-window.cpp
@@ -467,9 +467,9 @@ void MainWindow::onFirstLoad()
 	connect(swin, &StartWindow::languageChanged, &m_languageLoader, &LanguageLoader::setLanguage);
 	connect(swin, &StartWindow::settingsChanged, m_settingsDock, &SettingsDock::reset);
 	connect(swin, &StartWindow::sourceChanged, this, &MainWindow::setSource);
-	QShortcut *accept = new QShortcut(getKeySequence(m_settings, "keyAcceptDialogue", Qt::CTRL + Qt::Key_Y), swin);
+	QShortcut *accept = new QShortcut(getKeySequence(m_settings, "keyAcceptDialogue", Qt::Key_Y), swin);
 		connect(accept, &QShortcut::activated, swin, &QDialog::accept);
-	QShortcut *decline = new QShortcut(getKeySequence(m_settings, "keyDeclineDialogue", Qt::CTRL + Qt::Key_N), swin);
+	QShortcut *decline = new QShortcut(getKeySequence(m_settings, "keyDeclineDialogue", Qt::Key_N), swin);
 		connect(decline, &QShortcut::activated, swin, &QDialog::reject);
 	swin->show();
 }
@@ -796,9 +796,9 @@ void MainWindow::options()
 	connect(options, &OptionsWindow::languageChanged, &m_languageLoader, &LanguageLoader::setLanguage);
 	connect(options, &OptionsWindow::settingsChanged, m_settingsDock, &SettingsDock::reset);
 	connect(options, &QDialog::accepted, this, &MainWindow::optionsClosed);
-	QShortcut *accept = new QShortcut(getKeySequence(m_settings, "keyAcceptDialogue", Qt::CTRL + Qt::Key_Y), options);
+	QShortcut *accept = new QShortcut(getKeySequence(m_settings, "keyAcceptDialogue", Qt::Key_Y), options);
 		connect(accept, &QShortcut::activated, options, &QDialog::accept);
-	QShortcut *decline = new QShortcut(getKeySequence(m_settings, "keyDeclineDialogue", Qt::CTRL + Qt::Key_N), options);
+	QShortcut *decline = new QShortcut(getKeySequence(m_settings, "keyDeclineDialogue", Qt::Key_N), options);
 		connect(decline, &QShortcut::activated, options, &QDialog::reject);
 	options->show();
 

--- a/src/gui/src/main-window.cpp
+++ b/src/gui/src/main-window.cpp
@@ -467,6 +467,10 @@ void MainWindow::onFirstLoad()
 	connect(swin, &StartWindow::languageChanged, &m_languageLoader, &LanguageLoader::setLanguage);
 	connect(swin, &StartWindow::settingsChanged, m_settingsDock, &SettingsDock::reset);
 	connect(swin, &StartWindow::sourceChanged, this, &MainWindow::setSource);
+	QShortcut *accept = new QShortcut(getKeySequence(m_settings, "keyAcceptDialogue", Qt::CTRL + Qt::Key_Y), swin);
+		connect(accept, &QShortcut::activated, swin, &QDialog::accept);
+	QShortcut *decline = new QShortcut(getKeySequence(m_settings, "keyDeclineDialogue", Qt::CTRL + Qt::Key_N), swin);
+		connect(decline, &QShortcut::activated, swin, &QDialog::reject);
 	swin->show();
 }
 
@@ -792,6 +796,10 @@ void MainWindow::options()
 	connect(options, &OptionsWindow::languageChanged, &m_languageLoader, &LanguageLoader::setLanguage);
 	connect(options, &OptionsWindow::settingsChanged, m_settingsDock, &SettingsDock::reset);
 	connect(options, &QDialog::accepted, this, &MainWindow::optionsClosed);
+	QShortcut *accept = new QShortcut(getKeySequence(m_settings, "keyAcceptDialogue", Qt::CTRL + Qt::Key_Y), options);
+		connect(accept, &QShortcut::activated, options, &QDialog::accept);
+	QShortcut *decline = new QShortcut(getKeySequence(m_settings, "keyDeclineDialogue", Qt::CTRL + Qt::Key_N), options);
+		connect(decline, &QShortcut::activated, options, &QDialog::reject);
 	options->show();
 
 	DONE();

--- a/src/gui/src/main-window.cpp
+++ b/src/gui/src/main-window.cpp
@@ -467,10 +467,6 @@ void MainWindow::onFirstLoad()
 	connect(swin, &StartWindow::languageChanged, &m_languageLoader, &LanguageLoader::setLanguage);
 	connect(swin, &StartWindow::settingsChanged, m_settingsDock, &SettingsDock::reset);
 	connect(swin, &StartWindow::sourceChanged, this, &MainWindow::setSource);
-	QShortcut *accept = new QShortcut(getKeySequence(m_settings, "keyAcceptDialogue", Qt::Key_Y), swin);
-		connect(accept, &QShortcut::activated, swin, &QDialog::accept);
-	QShortcut *decline = new QShortcut(getKeySequence(m_settings, "keyDeclineDialogue", Qt::Key_N), swin);
-		connect(decline, &QShortcut::activated, swin, &QDialog::reject);
 	swin->show();
 }
 
@@ -796,10 +792,6 @@ void MainWindow::options()
 	connect(options, &OptionsWindow::languageChanged, &m_languageLoader, &LanguageLoader::setLanguage);
 	connect(options, &OptionsWindow::settingsChanged, m_settingsDock, &SettingsDock::reset);
 	connect(options, &QDialog::accepted, this, &MainWindow::optionsClosed);
-	QShortcut *accept = new QShortcut(getKeySequence(m_settings, "keyAcceptDialogue", Qt::Key_Y), options);
-		connect(accept, &QShortcut::activated, options, &QDialog::accept);
-	QShortcut *decline = new QShortcut(getKeySequence(m_settings, "keyDeclineDialogue", Qt::Key_N), options);
-		connect(decline, &QShortcut::activated, options, &QDialog::reject);
 	options->show();
 
 	DONE();

--- a/src/gui/src/settings/options-window.cpp
+++ b/src/gui/src/settings/options-window.cpp
@@ -13,6 +13,7 @@
 #include <QStandardItem>
 #include <QStandardItemModel>
 #include <QtConcurrent>
+//#include <QShortcut>
 #include <ui_options-window.h>
 #include <algorithm>
 #include "analytics.h"
@@ -126,6 +127,9 @@ OptionsWindow::OptionsWindow(Profile *profile, ThemeLoader *themeLoader, QWidget
 
 	const QStringList ftypes { "ind", "in", "id", "nd", "i", "n", "d" };
 	ui->comboFavoritesDisplay->setCurrentIndex(ftypes.indexOf(settings->value("favorites_display", "ind").toString()));
+
+	ui->keyAcceptDialogue->setKeySequence(getKeySequence(settings, "keyAcceptDialogue", QKeySequence::Quit, Qt::CTRL + Qt::Key_Y));
+	ui->keyDeclineDialogue->setKeySequence(getKeySequence(settings, "keyDeclineDialogue", QKeySequence::Quit, Qt::CTRL + Qt::Key_N));
 
 	// Metadata using Windows Property System
 	#ifndef WIN_FILE_PROPS
@@ -463,6 +467,10 @@ void OptionsWindow::on_buttonFilenamePlus_clicked()
 {
 	FilenameWindow *fw = new FilenameWindow(m_profile, ui->lineFilename->text(), this);
 	connect(fw, &FilenameWindow::validated, ui->lineFilename, &QLineEdit::setText);
+	/*QShortcut *accept = new QShortcut(getKeySequence(settings, "keyAcceptDialogue", Qt::CTRL + Qt::Key_Y), fw);
+		connect(accept, &QShortcut::activated, fw, &QDialog::accept);
+	QShortcut *decline = new QShortcut(getKeySequence(settings, "keyDeclineDialogue", Qt::CTRL + Qt::Key_N), fw);
+		connect(decline, &QShortcut::activated, fw, &QDialog::reject);*/
 	fw->show();
 }
 void OptionsWindow::on_buttonFavoritesPlus_clicked()
@@ -476,6 +484,10 @@ void OptionsWindow::on_buttonCustom_clicked()
 {
 	auto *cw = new CustomWindow(this);
 	connect(cw, &CustomWindow::validated, this, &OptionsWindow::addCustom);
+	/*QShortcut *accept = new QShortcut(getKeySequence(settings, "keyAcceptDialogue", Qt::CTRL + Qt::Key_Y), cw);
+		connect(accept, &QShortcut::activated, cw, &QDialog::accept);
+	QShortcut *decline = new QShortcut(getKeySequence(settings, "keyDeclineDialogue", Qt::CTRL + Qt::Key_N), cw);
+		connect(decline, &QShortcut::activated, cw, &QDialog::reject);*/
 	cw->show();
 }
 void OptionsWindow::addCustom(const QString &name, const QString &tags)
@@ -490,6 +502,10 @@ void OptionsWindow::on_buttonFilenames_clicked()
 {
 	auto *cw = new ConditionWindow();
 	connect(cw, &ConditionWindow::validated, this, &OptionsWindow::addFilename);
+	/*QShortcut *accept = new QShortcut(getKeySequence(settings, "keyAcceptDialogue", Qt::CTRL + Qt::Key_Y), cw);
+		connect(accept, &QShortcut::activated, cw, &QDialog::accept);
+	QShortcut *decline = new QShortcut(getKeySequence(settings, "keyDeclineDialogue", Qt::CTRL + Qt::Key_N), cw);
+		connect(decline, &QShortcut::activated, cw, &QDialog::accept);*/
 	cw->show();
 }
 void OptionsWindow::addFilename(const QString &condition, const QString &filename, const QString &folder)
@@ -560,6 +576,10 @@ void OptionsWindow::addLogFile()
 {
 	auto *logWindow = new LogWindow(-1, m_profile, this);
 	connect(logWindow, &LogWindow::validated, this, &OptionsWindow::setLogFile);
+	/*QShortcut *accept = new QShortcut(getKeySequence(settings, "keyAcceptDialogue", Qt::CTRL + Qt::Key_Y), logWindow);
+		connect(accept, &QShortcut::activated, logWindow, &QDialog::accept);
+	QShortcut *decline = new QShortcut(getKeySequence(settings, "keyDeclineDialogue", Qt::CTRL + Qt::Key_N), logWindow);
+		connect(decline, &QShortcut::activated, logWindow, &QDialog::reject);*/
 	logWindow->show();
 }
 
@@ -670,6 +690,10 @@ void OptionsWindow::addWebService()
 {
 	auto *wsWindow = new WebServiceWindow(nullptr, this);
 	connect(wsWindow, &WebServiceWindow::validated, this, &OptionsWindow::setWebService);
+	/*QShortcut *accept = new QShortcut(getKeySequence(settings, "keyAcceptDialogue", Qt::CTRL + Qt::Key_Y), wsWindow);
+		connect(accept, &QShortcut::activated, wsWindow, &QDialog::accept);
+	QShortcut *decline = new QShortcut(getKeySequence(settings, "keyDeclineDialogue", Qt::CTRL + Qt::Key_N), wsWindow);
+		connect(decline, &QShortcut::activated, wsWindow, &QDialog::reject);*/
 	wsWindow->show();
 }
 
@@ -982,6 +1006,9 @@ void OptionsWindow::save()
 		settings->setValue("favorites_display", ftypes.at(ui->comboFavoritesDisplay->currentIndex()));
 		m_profile->emitFavorite();
 	}
+
+	settings->setValue("keyAcceptDialogue", ui->keyAcceptDialogue->keySequence().toString());
+	settings->setValue("keyDeclineDialogue", ui->keyDeclineDialogue->keySequence().toString());
 
 	// Log
 	settings->beginGroup("Log");

--- a/src/gui/src/settings/options-window.cpp
+++ b/src/gui/src/settings/options-window.cpp
@@ -13,7 +13,6 @@
 #include <QStandardItem>
 #include <QStandardItemModel>
 #include <QtConcurrent>
-//#include <QShortcut>
 #include <ui_options-window.h>
 #include <algorithm>
 #include "analytics.h"
@@ -58,6 +57,7 @@ OptionsWindow::OptionsWindow(Profile *profile, ThemeLoader *themeLoader, QWidget
 	ui->setupUi(this);
 
 	QSettings *settings = profile->getSettings();
+	setupDialogShortcuts(this, settings);
 
 	ui->splitter->setSizes({ 160, ui->stackedWidget->sizeHint().width() });
 	ui->splitter->setStretchFactor(0, 0);
@@ -128,8 +128,8 @@ OptionsWindow::OptionsWindow(Profile *profile, ThemeLoader *themeLoader, QWidget
 	const QStringList ftypes { "ind", "in", "id", "nd", "i", "n", "d" };
 	ui->comboFavoritesDisplay->setCurrentIndex(ftypes.indexOf(settings->value("favorites_display", "ind").toString()));
 
-	ui->keyAcceptDialogue->setKeySequence(getKeySequence(settings, "keyAcceptDialogue", Qt::Key_Y));
-	ui->keyDeclineDialogue->setKeySequence(getKeySequence(settings, "keyDeclineDialogue", Qt::Key_N));
+	ui->keyAcceptDialogue->setKeySequence(getKeySequence(settings, "keyAcceptDialog", Qt::CTRL + Qt::Key_Y));
+	ui->keyDeclineDialogue->setKeySequence(getKeySequence(settings, "keyDeclineDialog", Qt::CTRL + Qt::Key_N));
 
 	// Metadata using Windows Property System
 	#ifndef WIN_FILE_PROPS
@@ -467,16 +467,14 @@ void OptionsWindow::on_buttonFilenamePlus_clicked()
 {
 	FilenameWindow *fw = new FilenameWindow(m_profile, ui->lineFilename->text(), this);
 	connect(fw, &FilenameWindow::validated, ui->lineFilename, &QLineEdit::setText);
-	/*QShortcut *accept = new QShortcut(getKeySequence(settings, "keyAcceptDialogue", Qt::Key_Y), fw);
-		connect(accept, &QShortcut::activated, fw, &QDialog::accept);
-	QShortcut *decline = new QShortcut(getKeySequence(settings, "keyDeclineDialogue", Qt::Key_N), fw);
-		connect(decline, &QShortcut::activated, fw, &QDialog::reject);*/
+	setupDialogShortcuts(fw, m_profile->getSettings());
 	fw->show();
 }
 void OptionsWindow::on_buttonFavoritesPlus_clicked()
 {
 	FilenameWindow *fw = new FilenameWindow(m_profile, ui->lineFavorites->text(), this);
 	connect(fw, &FilenameWindow::validated, ui->lineFavorites, &QLineEdit::setText);
+	setupDialogShortcuts(fw, m_profile->getSettings());
 	fw->show();
 }
 
@@ -484,10 +482,7 @@ void OptionsWindow::on_buttonCustom_clicked()
 {
 	auto *cw = new CustomWindow(this);
 	connect(cw, &CustomWindow::validated, this, &OptionsWindow::addCustom);
-	/*QShortcut *accept = new QShortcut(getKeySequence(settings, "keyAcceptDialogue", Qt::Key_Y), cw);
-		connect(accept, &QShortcut::activated, cw, &QDialog::accept);
-	QShortcut *decline = new QShortcut(getKeySequence(settings, "keyDeclineDialogue", Qt::Key_N), cw);
-		connect(decline, &QShortcut::activated, cw, &QDialog::reject);*/
+	setupDialogShortcuts(cw, m_profile->getSettings());
 	cw->show();
 }
 void OptionsWindow::addCustom(const QString &name, const QString &tags)
@@ -502,10 +497,7 @@ void OptionsWindow::on_buttonFilenames_clicked()
 {
 	auto *cw = new ConditionWindow();
 	connect(cw, &ConditionWindow::validated, this, &OptionsWindow::addFilename);
-	/*QShortcut *accept = new QShortcut(getKeySequence(settings, "keyAcceptDialogue", Qt::Key_Y), cw);
-		connect(accept, &QShortcut::activated, cw, &QDialog::accept);
-	QShortcut *decline = new QShortcut(getKeySequence(settings, "keyDeclineDialogue", Qt::Key_N), cw);
-		connect(decline, &QShortcut::activated, cw, &QDialog::accept);*/
+	setupDialogShortcuts(cw, m_profile->getSettings());
 	cw->show();
 }
 void OptionsWindow::addFilename(const QString &condition, const QString &filename, const QString &folder)
@@ -576,10 +568,7 @@ void OptionsWindow::addLogFile()
 {
 	auto *logWindow = new LogWindow(-1, m_profile, this);
 	connect(logWindow, &LogWindow::validated, this, &OptionsWindow::setLogFile);
-	/*QShortcut *accept = new QShortcut(getKeySequence(settings, "keyAcceptDialogue", Qt::Key_Y), logWindow);
-		connect(accept, &QShortcut::activated, logWindow, &QDialog::accept);
-	QShortcut *decline = new QShortcut(getKeySequence(settings, "keyDeclineDialogue", Qt::Key_N), logWindow);
-		connect(decline, &QShortcut::activated, logWindow, &QDialog::reject);*/
+	setupDialogShortcuts(logWindow, m_profile->getSettings());
 	logWindow->show();
 }
 
@@ -587,6 +576,7 @@ void OptionsWindow::editLogFile(int index)
 {
 	auto *logWindow = new LogWindow(index, m_profile, this);
 	connect(logWindow, &LogWindow::validated, this, &OptionsWindow::setLogFile);
+	setupDialogShortcuts(logWindow, m_profile->getSettings());
 	logWindow->show();
 }
 
@@ -690,10 +680,7 @@ void OptionsWindow::addWebService()
 {
 	auto *wsWindow = new WebServiceWindow(nullptr, this);
 	connect(wsWindow, &WebServiceWindow::validated, this, &OptionsWindow::setWebService);
-	/*QShortcut *accept = new QShortcut(getKeySequence(settings, "keyAcceptDialogue", Qt::Key_Y), wsWindow);
-		connect(accept, &QShortcut::activated, wsWindow, &QDialog::accept);
-	QShortcut *decline = new QShortcut(getKeySequence(settings, "keyDeclineDialogue", Qt::Key_N), wsWindow);
-		connect(decline, &QShortcut::activated, wsWindow, &QDialog::reject);*/
+	setupDialogShortcuts(wsWindow, m_profile->getSettings());
 	wsWindow->show();
 }
 
@@ -702,6 +689,7 @@ void OptionsWindow::editWebService(int id)
 	int pos = m_webServicesIds[id];
 	auto *wsWindow = new WebServiceWindow(&m_webServices[pos], this);
 	connect(wsWindow, &WebServiceWindow::validated, this, &OptionsWindow::setWebService);
+	setupDialogShortcuts(wsWindow, m_profile->getSettings());
 	wsWindow->show();
 }
 
@@ -1007,8 +995,8 @@ void OptionsWindow::save()
 		m_profile->emitFavorite();
 	}
 
-	settings->setValue("keyAcceptDialogue", ui->keyAcceptDialogue->keySequence().toString());
-	settings->setValue("keyDeclineDialogue", ui->keyDeclineDialogue->keySequence().toString());
+	settings->setValue("keyAcceptDialog", ui->keyAcceptDialogue->keySequence().toString());
+	settings->setValue("keyDeclineDialog", ui->keyDeclineDialogue->keySequence().toString());
 
 	// Log
 	settings->beginGroup("Log");

--- a/src/gui/src/settings/options-window.cpp
+++ b/src/gui/src/settings/options-window.cpp
@@ -128,8 +128,8 @@ OptionsWindow::OptionsWindow(Profile *profile, ThemeLoader *themeLoader, QWidget
 	const QStringList ftypes { "ind", "in", "id", "nd", "i", "n", "d" };
 	ui->comboFavoritesDisplay->setCurrentIndex(ftypes.indexOf(settings->value("favorites_display", "ind").toString()));
 
-	ui->keyAcceptDialogue->setKeySequence(getKeySequence(settings, "keyAcceptDialogue", QKeySequence::Quit, Qt::CTRL + Qt::Key_Y));
-	ui->keyDeclineDialogue->setKeySequence(getKeySequence(settings, "keyDeclineDialogue", QKeySequence::Quit, Qt::CTRL + Qt::Key_N));
+	ui->keyAcceptDialogue->setKeySequence(getKeySequence(settings, "keyAcceptDialogue", Qt::Key_Y));
+	ui->keyDeclineDialogue->setKeySequence(getKeySequence(settings, "keyDeclineDialogue", Qt::Key_N));
 
 	// Metadata using Windows Property System
 	#ifndef WIN_FILE_PROPS
@@ -467,9 +467,9 @@ void OptionsWindow::on_buttonFilenamePlus_clicked()
 {
 	FilenameWindow *fw = new FilenameWindow(m_profile, ui->lineFilename->text(), this);
 	connect(fw, &FilenameWindow::validated, ui->lineFilename, &QLineEdit::setText);
-	/*QShortcut *accept = new QShortcut(getKeySequence(settings, "keyAcceptDialogue", Qt::CTRL + Qt::Key_Y), fw);
+	/*QShortcut *accept = new QShortcut(getKeySequence(settings, "keyAcceptDialogue", Qt::Key_Y), fw);
 		connect(accept, &QShortcut::activated, fw, &QDialog::accept);
-	QShortcut *decline = new QShortcut(getKeySequence(settings, "keyDeclineDialogue", Qt::CTRL + Qt::Key_N), fw);
+	QShortcut *decline = new QShortcut(getKeySequence(settings, "keyDeclineDialogue", Qt::Key_N), fw);
 		connect(decline, &QShortcut::activated, fw, &QDialog::reject);*/
 	fw->show();
 }
@@ -484,9 +484,9 @@ void OptionsWindow::on_buttonCustom_clicked()
 {
 	auto *cw = new CustomWindow(this);
 	connect(cw, &CustomWindow::validated, this, &OptionsWindow::addCustom);
-	/*QShortcut *accept = new QShortcut(getKeySequence(settings, "keyAcceptDialogue", Qt::CTRL + Qt::Key_Y), cw);
+	/*QShortcut *accept = new QShortcut(getKeySequence(settings, "keyAcceptDialogue", Qt::Key_Y), cw);
 		connect(accept, &QShortcut::activated, cw, &QDialog::accept);
-	QShortcut *decline = new QShortcut(getKeySequence(settings, "keyDeclineDialogue", Qt::CTRL + Qt::Key_N), cw);
+	QShortcut *decline = new QShortcut(getKeySequence(settings, "keyDeclineDialogue", Qt::Key_N), cw);
 		connect(decline, &QShortcut::activated, cw, &QDialog::reject);*/
 	cw->show();
 }
@@ -502,9 +502,9 @@ void OptionsWindow::on_buttonFilenames_clicked()
 {
 	auto *cw = new ConditionWindow();
 	connect(cw, &ConditionWindow::validated, this, &OptionsWindow::addFilename);
-	/*QShortcut *accept = new QShortcut(getKeySequence(settings, "keyAcceptDialogue", Qt::CTRL + Qt::Key_Y), cw);
+	/*QShortcut *accept = new QShortcut(getKeySequence(settings, "keyAcceptDialogue", Qt::Key_Y), cw);
 		connect(accept, &QShortcut::activated, cw, &QDialog::accept);
-	QShortcut *decline = new QShortcut(getKeySequence(settings, "keyDeclineDialogue", Qt::CTRL + Qt::Key_N), cw);
+	QShortcut *decline = new QShortcut(getKeySequence(settings, "keyDeclineDialogue", Qt::Key_N), cw);
 		connect(decline, &QShortcut::activated, cw, &QDialog::accept);*/
 	cw->show();
 }
@@ -576,9 +576,9 @@ void OptionsWindow::addLogFile()
 {
 	auto *logWindow = new LogWindow(-1, m_profile, this);
 	connect(logWindow, &LogWindow::validated, this, &OptionsWindow::setLogFile);
-	/*QShortcut *accept = new QShortcut(getKeySequence(settings, "keyAcceptDialogue", Qt::CTRL + Qt::Key_Y), logWindow);
+	/*QShortcut *accept = new QShortcut(getKeySequence(settings, "keyAcceptDialogue", Qt::Key_Y), logWindow);
 		connect(accept, &QShortcut::activated, logWindow, &QDialog::accept);
-	QShortcut *decline = new QShortcut(getKeySequence(settings, "keyDeclineDialogue", Qt::CTRL + Qt::Key_N), logWindow);
+	QShortcut *decline = new QShortcut(getKeySequence(settings, "keyDeclineDialogue", Qt::Key_N), logWindow);
 		connect(decline, &QShortcut::activated, logWindow, &QDialog::reject);*/
 	logWindow->show();
 }
@@ -690,9 +690,9 @@ void OptionsWindow::addWebService()
 {
 	auto *wsWindow = new WebServiceWindow(nullptr, this);
 	connect(wsWindow, &WebServiceWindow::validated, this, &OptionsWindow::setWebService);
-	/*QShortcut *accept = new QShortcut(getKeySequence(settings, "keyAcceptDialogue", Qt::CTRL + Qt::Key_Y), wsWindow);
+	/*QShortcut *accept = new QShortcut(getKeySequence(settings, "keyAcceptDialogue", Qt::Key_Y), wsWindow);
 		connect(accept, &QShortcut::activated, wsWindow, &QDialog::accept);
-	QShortcut *decline = new QShortcut(getKeySequence(settings, "keyDeclineDialogue", Qt::CTRL + Qt::Key_N), wsWindow);
+	QShortcut *decline = new QShortcut(getKeySequence(settings, "keyDeclineDialogue", Qt::Key_N), wsWindow);
 		connect(decline, &QShortcut::activated, wsWindow, &QDialog::reject);*/
 	wsWindow->show();
 }

--- a/src/gui/src/settings/options-window.ui
+++ b/src/gui/src/settings/options-window.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>666</width>
-    <height>528</height>
+    <height>542</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -1054,8 +1054,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>68</width>
-             <height>16</height>
+             <width>359</width>
+             <height>440</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="scrollAreaWidgetLayout">
@@ -1687,8 +1687,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>308</width>
-             <height>417</height>
+             <width>288</width>
+             <height>449</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -2284,8 +2284,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>226</width>
-             <height>810</height>
+             <width>212</width>
+             <height>869</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_8">

--- a/src/gui/src/settings/options-window.ui
+++ b/src/gui/src/settings/options-window.ui
@@ -1054,8 +1054,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>363</width>
-             <height>438</height>
+             <width>68</width>
+             <height>16</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="scrollAreaWidgetLayout">
@@ -1496,6 +1496,34 @@
           </property>
          </widget>
         </item>
+        <item row="10" column="0">
+         <widget class="QLabel" name="labelDeclineDialogue">
+          <property name="text">
+           <string>Decline dialogue</string>
+          </property>
+         </widget>
+        </item>
+        <item row="10" column="1">
+         <widget class="QKeySequenceEdit" name="keyDeclineDialogue">
+          <property name="keySequence">
+           <string>Ctrl+N</string>
+          </property>
+         </widget>
+        </item>
+        <item row="9" column="0">
+         <widget class="QLabel" name="labelAcceptDialogue">
+          <property name="text">
+           <string>Accept dialogue</string>
+          </property>
+         </widget>
+        </item>
+        <item row="9" column="1">
+         <widget class="QKeySequenceEdit" name="keyAcceptDialogue">
+          <property name="keySequence">
+           <string>Ctrl+N</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </widget>
       <widget class="QWidget" name="pageInterfaceMainWindow">
@@ -1659,8 +1687,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>381</width>
-             <height>483</height>
+             <width>308</width>
+             <height>417</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -2256,7 +2284,7 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>367</width>
+             <width>226</width>
              <height>810</height>
             </rect>
            </property>

--- a/src/gui/src/settings/start-window.cpp
+++ b/src/gui/src/settings/start-window.cpp
@@ -62,10 +62,6 @@ void StartWindow::on_buttonFilenamePlus_clicked()
 {
 	FilenameWindow *fw = new FilenameWindow(m_profile, ui->lineFilename->text(), this);
 	connect(fw, &FilenameWindow::validated, ui->lineFilename, &QLineEdit::setText);
-	/*QShortcut *accept = new QShortcut(getKeySequence(m_settings, "keyAcceptDialogue", Qt::CTRL + Qt::Key_Y), fw);
-		connect(accept, &QShortcut::activated, fw, &QDialog::accept);
-	QShortcut *decline = new QShortcut(getKeySequence(m_settings, "keyDeclineDialogue", Qt::CTRL + Qt::Key_N), fw);
-		connect(decline, &QShortcut::activated, fw, &QDialog::reject);*/
 	fw->show();
 }
 

--- a/src/gui/src/settings/start-window.cpp
+++ b/src/gui/src/settings/start-window.cpp
@@ -17,6 +17,8 @@ StartWindow::StartWindow(Profile *profile, QWidget *parent)
 	: QDialog(parent), ui(new Ui::StartWindow), m_profile(profile)
 {
 	ui->setupUi(this);
+	setupDialogShortcuts(this, m_profile->getSettings());
+
 	ui->labelHelp->setText(ui->labelHelp->text().replace("{website}", PROJECT_WEBSITE_URL));
 	ui->labelHelp->setText(ui->labelHelp->text().replace("{github}", PROJECT_GITHUB_URL));
 

--- a/src/gui/src/settings/start-window.cpp
+++ b/src/gui/src/settings/start-window.cpp
@@ -62,6 +62,10 @@ void StartWindow::on_buttonFilenamePlus_clicked()
 {
 	FilenameWindow *fw = new FilenameWindow(m_profile, ui->lineFilename->text(), this);
 	connect(fw, &FilenameWindow::validated, ui->lineFilename, &QLineEdit::setText);
+	/*QShortcut *accept = new QShortcut(getKeySequence(m_settings, "keyAcceptDialogue", Qt::CTRL + Qt::Key_Y), fw);
+		connect(accept, &QShortcut::activated, fw, &QDialog::accept);
+	QShortcut *decline = new QShortcut(getKeySequence(m_settings, "keyDeclineDialogue", Qt::CTRL + Qt::Key_N), fw);
+		connect(decline, &QShortcut::activated, fw, &QDialog::reject);*/
 	fw->show();
 }
 

--- a/src/gui/src/viewer/details-window.cpp
+++ b/src/gui/src/viewer/details-window.cpp
@@ -3,12 +3,14 @@
 #include <ui_details-window.h>
 #include "helpers.h"
 #include "models/image.h"
+#include "models/profile.h"
 
 
 DetailsWindow::DetailsWindow(Profile *profile, QWidget *parent)
 	: QDialog(parent), ui(new Ui::DetailsWindow), m_profile(profile)
 {
 	ui->setupUi(this);
+	setupDialogShortcuts(this, m_profile->getSettings());
 }
 
 DetailsWindow::~DetailsWindow()

--- a/src/gui/src/viewer/zoom-window.cpp
+++ b/src/gui/src/viewer/zoom-window.cpp
@@ -220,6 +220,12 @@ void ZoomWindow::go()
 	m_detailsWindow = new DetailsWindow(m_profile, this);
 	colore();
 
+	QShortcut *accept = new QShortcut(getKeySequence(m_settings, "keyAcceptDialogue", Qt::CTRL + Qt::Key_Y), m_detailsWindow);
+		//connect(accept, &QShortcut::activated, m_detailsWindow, &QDialog::done(0));
+		connect(accept, &QShortcut::activated, m_detailsWindow, &QDialog::accept);
+	QShortcut *decline = new QShortcut(getKeySequence(m_settings, "keyDeclineDialogue", Qt::CTRL + Qt::Key_N), m_detailsWindow);
+		connect(decline, &QShortcut::activated, m_detailsWindow, &QDialog::accept);
+
 	// Load image details (exact tags & co)
 	connect(m_image.data(), &Image::finishedLoadingTags, this, &ZoomWindow::replyFinishedDetails, Qt::UniqueConnection);
 	m_image->loadDetails();

--- a/src/gui/src/viewer/zoom-window.cpp
+++ b/src/gui/src/viewer/zoom-window.cpp
@@ -220,10 +220,10 @@ void ZoomWindow::go()
 	m_detailsWindow = new DetailsWindow(m_profile, this);
 	colore();
 
-	QShortcut *accept = new QShortcut(getKeySequence(m_settings, "keyAcceptDialogue", Qt::CTRL + Qt::Key_Y), m_detailsWindow);
+	QShortcut *accept = new QShortcut(getKeySequence(m_settings, "keyAcceptDialogue", Qt::Key_Y), m_detailsWindow);
 		//connect(accept, &QShortcut::activated, m_detailsWindow, &QDialog::done(0));
 		connect(accept, &QShortcut::activated, m_detailsWindow, &QDialog::accept);
-	QShortcut *decline = new QShortcut(getKeySequence(m_settings, "keyDeclineDialogue", Qt::CTRL + Qt::Key_N), m_detailsWindow);
+	QShortcut *decline = new QShortcut(getKeySequence(m_settings, "keyDeclineDialogue", Qt::Key_N), m_detailsWindow);
 		connect(decline, &QShortcut::activated, m_detailsWindow, &QDialog::accept);
 
 	// Load image details (exact tags & co)

--- a/src/gui/src/viewer/zoom-window.cpp
+++ b/src/gui/src/viewer/zoom-window.cpp
@@ -52,6 +52,7 @@ ZoomWindow::ZoomWindow(QList<QSharedPointer<Image>> images, const QSharedPointer
 {
 	setAttribute(Qt::WA_DeleteOnClose);
 	connect(parent, &MainWindow::destroyed, this, &QWidget::deleteLater);
+
 	ui->setupUi(this);
 
 	m_pendingAction = PendingNothing;
@@ -219,12 +220,6 @@ void ZoomWindow::go()
 
 	m_detailsWindow = new DetailsWindow(m_profile, this);
 	colore();
-
-	QShortcut *accept = new QShortcut(getKeySequence(m_settings, "keyAcceptDialogue", Qt::Key_Y), m_detailsWindow);
-		//connect(accept, &QShortcut::activated, m_detailsWindow, &QDialog::done(0));
-		connect(accept, &QShortcut::activated, m_detailsWindow, &QDialog::accept);
-	QShortcut *decline = new QShortcut(getKeySequence(m_settings, "keyDeclineDialogue", Qt::Key_N), m_detailsWindow);
-		connect(decline, &QShortcut::activated, m_detailsWindow, &QDialog::accept);
 
 	// Load image details (exact tags & co)
 	connect(m_image.data(), &Image::finishedLoadingTags, this, &ZoomWindow::replyFinishedDetails, Qt::UniqueConnection);


### PR DESCRIPTION
I think this works but some of the dialogues are called from functions in "options-window.cpp". The problem(s) with that are:

1. QShortcut would need to be included (I think). Easy to fix but I don't know if you think it's worth the extra code.
2. Some of those functions don't have a pointer to the settings they would reference. I assume it's a bad idea to reference m_profile->getSettings() each time. Other options I can think of would be storing a pointer to settings in the class instance or passing the pointer into those functions as a parameter.

Adding support for FilenameWindow would also require including QShortcut, either in "start-window.cpp" or in "filename-window.cpp". Again, not sure if it's worth the extra code.