### PR TITLE
Added dependencies.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,6 +30,7 @@ for pm in pacman apt-get emerge yum; do
 				## Assumes default USE flags are enabled.
 				$permission emerge --noreplace --ask --verbose \
 					"dev-qt/qtcore" "dev-qt/qtscript" "dev-qt/qtmultimedia" "dev-qt/qtdeclarative" "dev-qt/qtsql" \
+					"dev-qt/qtnetwork" "dev-qt/qtnetworkauth" \
 					"sys-devel/gcc" "dev-util/cmake" "net-libs/nodejs" \
 				&& installed=1
 				;;


### PR DESCRIPTION
QtNetworkAuth is a new dependency added within the past few versions of Grabber or reorganisation of Gentoo packages. I noticed that something on my system had already pulled in qtnetwork-- I have not tested to confirm that it is required, but it seems very likely.