### PR TITLE
Fix sensitive images being skipped

### DIFF
--- a/docs/_docs/commands/szurubooru.js
+++ b/docs/_docs/commands/szurubooru.js
@@ -48,8 +48,15 @@ async function setTagCategory(name, category) {
 (async () => {
     // Szurubooru doesn't use the same ratings as most boorus so we need to map them
     const ratingsMap = {
+        "": "safe",
+        "g": "safe",
+        "general": "safe",
         "safe": "safe",
+        "s": "sketchy",
+        "sensitive": "sketchy",
+        "q": "sketchy",
         "questionable": "sketchy",
+        "e": "unsafe",
         "explicit": "unsafe",
     };
 


### PR DESCRIPTION
Fix for "sensitive" images being skipped from being uploaded. Also included additional redundant categories as catch-alls so that nothing is missed.