### PR TITLE
Update TypesScript to 4.9.3.

### DIFF
--- a/src/sites/Twitter/model.ts
+++ b/src/sites/Twitter/model.ts
@@ -172,9 +172,7 @@ export const source: ISource = {
                     const images: IImage[] = [];
                     for (const i in data) {
                         const img = parseTweet(data[i], false);
-                        if (img !== false) {
-                            images.push(img as any);
-                        }
+                        images.push(img as any);
                     }
 
                     return { images };

--- a/src/sites/package-lock.json
+++ b/src/sites/package-lock.json
@@ -4,6 +4,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "sites",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@types/jest": "27.4.1",
@@ -11,7 +12,7 @@
                 "jest": "27.5.1",
                 "ts-jest": "27.1.4",
                 "tslint": "6.1.3",
-                "typescript": "4.6.3",
+                "typescript": "4.9.3",
                 "xml2js": "0.4.23"
             }
         },
@@ -4015,9 +4016,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.6.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-            "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+            "version": "4.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
+            "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -7379,9 +7380,9 @@
             }
         },
         "typescript": {
-            "version": "4.6.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-            "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+            "version": "4.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
+            "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
             "dev": true
         },
         "universalify": {

--- a/src/sites/package.json
+++ b/src/sites/package.json
@@ -17,7 +17,7 @@
         "jest": "27.5.1",
         "ts-jest": "27.1.4",
         "tslint": "6.1.3",
-        "typescript": "4.6.3",
+        "typescript": "4.9.3",
         "xml2js": "0.4.23"
     }
 }


### PR DESCRIPTION
It catches one new error: `parseTweet` can never return a boolean or even a falsy value AFAICT.