### PR TITLE
Encode getTag URI

### DIFF
--- a/docs/_docs/commands/szurubooru.js
+++ b/docs/_docs/commands/szurubooru.js
@@ -7,7 +7,7 @@ const FormData = require("form-data");
 
 async function getTag(name) {
     try {
-        const res = await axios.get(`/tag/${name}`);
+        const res = await axios.get(`/tag/${encodeURIComponent(name)}`);
         return res.data;
     } catch (e) {
         if (e.response.status === 404) {


### PR DESCRIPTION
Fixed `getTag()` for tags that contained a "?" or "\\"