### PR TITLE
Added flush mode to video player to fix black screen on media loop

### DIFF
--- a/src/gui-qml/src/components/ImageScreen.qml
+++ b/src/gui-qml/src/components/ImageScreen.qml
@@ -155,6 +155,7 @@ Page {
 
                             sourceComponent: VideoPlayer {
                                 fillMode: VideoOutput.PreserveAspectFit
+                                flushMode: VideoOutput.FirstFrame
                                 source: showHd || !hasSample ? modelData.fileUrl : modelData.sampleUrl
                                 clip: true
                                 autoPlay: index == swipeView.currentIndex


### PR DESCRIPTION
I was finally able to track down the cause of the black screen appearing on video loop. The solution was found in the comments on the [QTBUG-49446](https://bugreports.qt.io/browse/QTBUG-49446) discussion page.
Build tested on linux using the latest master branch.