### PR TITLE
Add Referer header to Pixiv defaults to reduce 403 responses

### DIFF
--- a/src/sites/Pixiv/www.pixiv.net/defaults.ini
+++ b/src/sites/Pixiv/www.pixiv.net/defaults.ini
@@ -24,3 +24,4 @@ App-OS=android
 App-OS-Version=9.0
 App-Version=5.0.234
 User-Agent="PixivAndroidApp/5.0.234 (Android 9.0; Pixel 3)"
+Pixiv="https://www.pixiv.net/"


### PR DESCRIPTION
For some posts Pixiv responds with a 403 on webserver layer (nginx response).

I assume this is a measure against hotlinking all images of a gallery with ~14+ images on another website, might be a simple regex in nginx to require this header for `/img-original/...p15.img` and upwards (not further analyzed).

During investigation i came across this extension which also simply adds this header to direct requests to media:
https://chromewebstore.google.com/detail/pixiv-image-extension/cpacgkdedbhileoelnmdegkedcoammhg

This is a draft PR until i've investigated other failed downloads or until i'm sure this change actually helps.