### PR TITLE
fixing arch build process

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,7 @@ for pm in pacman apt-get emerge yum; do
 		case "$pm" in
 			pacman)
 				$permission pacman -Sy
-				$permission pacman -S "qt" "gcc" "cmake" "libpulse" "nodejs" "npm" && installed=1
+				$permission pacman -S "qt6" "gcc" "cmake" "libpulse" "nodejs" "npm" && installed=1
 				;;
 			apt-get)
 				$permission apt-get install -qq "qtbase5-dev" "qtscript5-dev" "qtmultimedia5-dev" "qtdeclarative5-dev" "qttools5-dev" "qttools5-dev-tools" "libqt5networkauth5-dev" || continue


### PR DESCRIPTION
Specifically, I'm using KDE w/ QT6. 'qt' isn't a package anymore but Qt6 should be generally standard by now. Could just make different builds for qt5 or just use user input for whether you want 5 or 6. However, this should generally fix the issue.

I'm aware it's not a permanent fix or a long-term fix but the normal release will give you: warning: direct reference to protected function `_ZN21QNetworkAccessManager13createRequestENS_9OperationERK15QNetworkRequestP9QIODevice' in `/usr/lib/libQt6Network.so.6' may break pointer equality
./Grabber: _ZN21QNetworkAccessManager13createRequestENS_9OperationERK15QNetworkRequestP9QIODevice: /usr/lib/libQt6Network.so.6: error due to GNU_PROPERTY_1_NEEDED_INDIRECT_EXTERN_ACCESS

I did take a cursory look and the issue might be in async-image.cpp but I could be off.

All the best.