### PR TITLE
NHentai model hostname corrected.

### DIFF
--- a/src/sites/NHentai/model.ts
+++ b/src/sites/NHentai/model.ts
@@ -84,7 +84,7 @@ export const source: ISource = {
                             name: gallery["title"]["english"],
                             created_at: gallery["upload_date"],
                             tags: gallery["tags"].map(makeTag),
-                            preview_url: "https://t.nhentai.net/galleries/" + gallery["media_id"] + "/thumb." + extensionMap[thumb["t"]],
+                            preview_url: "https://t1.nhentai.net/galleries/" + gallery["media_id"] + "/thumb." + extensionMap[thumb["t"]],
                             preview_width: thumb["w"],
                             preview_height: thumb["h"],
                         };
@@ -112,10 +112,10 @@ export const source: ISource = {
                         images.push({
                             created_at: data["upload_date"],
                             tags: data["tags"].map(makeTag),
-                            file_url: "https://i.nhentai.net/galleries/" + data["media_id"] + "/" + index + "." + extensionMap[image["t"]],
+                            file_url: "https://i1.nhentai.net/galleries/" + data["media_id"] + "/" + index + "." + extensionMap[image["t"]],
                             width: image["w"],
                             height: image["h"],
-                            preview_url: "https://t.nhentai.net/galleries/" + data["media_id"] + "/" + index + "t." + extensionMap[image["t"]],
+                            preview_url: "https://t1.nhentai.net/galleries/" + data["media_id"] + "/" + index + "t." + extensionMap[image["t"]],
                         });
                     }
 


### PR DESCRIPTION
Valid hostnames are:

```
i1.nhentai.net
i2.nhentai.net
i3.nhentai.net
i4.nhentai.net

t1.nhentai.net
t2.nhentai.net
t3.nhentai.net
t4.nhentai.net
```

Haven't looked into the code much yet, but I don't suppose you support checking availability of multiple CDN-like endpoints. Otherwise, could add all as mirrors and try each until found.
