### PR TITLE
anime-pictures.net model updated

### DIFF
--- a/src/sites/Anime pictures/anime-pictures.net/defaults.ini
+++ b/src/sites/Anime pictures/anime-pictures.net/defaults.ini
@@ -5,7 +5,7 @@ cookies="sitelang=en", "kira=1"
 [sources]
 usedefault=false
 source_1=json
-source_2=regex
+source_2=
 source_3=
 source_4=
 

--- a/src/sites/Anime pictures/model.ts
+++ b/src/sites/Anime pictures/model.ts
@@ -33,6 +33,7 @@ function completeImage(image, raw){
     image.sample_url = noWebpAvif(image.sample_url || '');
     image.preview_url = noWebpAvif(image.preview_url || '');
     let md5Part = image.md5.substring(0, 3).concat('/', image.md5);
+    
     // If no URL is passed at all, build it ourselves.
     if (!image.preview_url && !image.sample_url && !image.file_url){
         let previewExt = raw['have_alpha'] === true ? 'png' : 'jpg';

--- a/src/sites/Anime pictures/model.ts
+++ b/src/sites/Anime pictures/model.ts
@@ -57,7 +57,7 @@ function completeImage(image, raw){
         // Valid but blocked by Cloudflare.
         // image.file_url = '//oimages.'.concat(mainHostname, '/', md5Part, '.', image.ext);
         
-        // Another seeming legacy tibit used internally with the previous above pattern.
+        // Another seeming legacy tidbit used internally with the previous above pattern.
         // image.file_url.concat('?if=ANIME-PICTURES.NET_-_', raw.file_url);
     }
     
@@ -103,24 +103,18 @@ function searchToUrl(page, search, previous){
         
         if (part.indexOf('width:') === 0){
             sizeToUrl(part.substr(6), 'res_x', ret);
-        }
-        else if (part.indexOf('height:') === 0){
+        }else if (part.indexOf('height:') === 0){
             sizeToUrl(part.substr(7), 'res_y', ret);
-        }
-        else if (part.indexOf('ratio:') === 0){
+        }else if (part.indexOf('ratio:') === 0){
             ret.push('aspect=' + part.substr(6));
-        }
-        else if (part.indexOf('order:') === 0){
+        }else if (part.indexOf('order:') === 0){
             ret.push('order_by=' + part.substr(6));
-        }
-        else if (part.indexOf('filetype:') === 0){
+        }else if (part.indexOf('filetype:') === 0){
             const ext = part.substr(9);
             ret.push('ext_' + ext + '=' + ext);
-        }
-        else if (part[0] === '-'){
+        }else if (part[0] === '-'){
             denied.push(encodeURIComponent(tag.substr(1)));
-        }
-        else if (tag.length > 0){
+        }else if (tag.length > 0){
             tags.push(encodeURIComponent(tag));
         }
     }


### PR DESCRIPTION
I updated `anime-pictures.net` model locally myself before realizing that you're working on it in the `develop` branch already. I suspect, looking at your code, coupled with my recent experience, that you are having difficulties with Cloudflare captcha there. Check out comments on Cloudflare and the workaround in my implementation. Full images load and cache on opening the viewer.

The [permalink to model file](<https://github.com/Erquint/imgbrd-grabber/blob/f2ade205b18a7959ed3e0a99a0005625336a7bfd/src/sites/Anime%20pictures/model.ts>) might be easier to inspect than the diff here in PR.

Please note that preloading is broken in my implementation — loads and caches samples instead. That really seems like a bug of Grabber, since it seems to log loading of details early into a preload — which is a prerequisite to full image link for this source — but seemingly only runs the details code of the model after already having tried to fetch a file URL yet to be defined. Or it could be lack of API usage on my part. In any case, I will insist that what Grabber does upon preloading must be as close as possible to what it does when scrolling to the next image in the viewer.

The existing code is a mess, I'm not gonna lie, and in order to properly refactor it — I would need the API documentation to not be outdated and incomplete as it currently stands.

I'm gonna leave this draft PR as a reference — close it whenever you feel like the model is fully functional one way or another.