### PR TITLE
Make menus on macOS more conventional

### DIFF
--- a/src/gui/src/main-window.cpp
+++ b/src/gui/src/main-window.cpp
@@ -81,6 +81,9 @@ void MainWindow::init(const QStringList &args, const QMap<QString, QString> &par
 	m_themeLoader = new ThemeLoader(savePath("themes/", true, false), m_settings, this);
 	m_themeLoader->setTheme(m_settings->value("theme", "Default").toString());
 	qApp->setStyle(baseStyle(m_settings));
+#ifdef Q_OS_MAC
+	QApplication::instance()->setAttribute(Qt::AA_DontShowIconsInMenus, true);
+#endif
 	ui->setupUi(this);
 
 	if (m_settings->value("Log/show", true).toBool()) {

--- a/src/gui/src/main-window.ui
+++ b/src/gui/src/main-window.ui
@@ -127,8 +127,8 @@
    </widget>
    <addaction name="menuFichier"/>
    <addaction name="menuEdit"/>
-   <addaction name="menuOutils"/>
    <addaction name="menuView"/>
+   <addaction name="menuOutils"/>
    <addaction name="menu_propos"/>
   </widget>
   <widget class="QDockWidget" name="dock_internet">


### PR DESCRIPTION
1. Tools should follow View in the menu bar.[^1]
2. Icons in menu items should be used sparingly.[^2]

<details>
<summary>Screenshots</summary>

Sample:
<img src="https://github.com/user-attachments/assets/45b09fa6-1e99-42f0-a1e0-018e1dd225df" width="654" height="270">

Before:
<img src="https://github.com/user-attachments/assets/d7148eea-4925-4358-8271-89e4af10179a" width="370" height="250">

After:
<img src="https://github.com/user-attachments/assets/34d8c83a-3d38-40c9-b01c-e1f937d3def8" width="370" height="250">

</details>

The menu items should also be in title case on macOS, but since sentence case is the convention on Windows (maybe Linux desktop world too), it will require more thought and I didn’t touch them yet.

[^1]: https://developer.apple.com/design/human-interface-guidelines/the-menu-bar#Anatomy
[^2]: OS X Human Interface Guidelines, “Using Icons in Menus” [archived](https://archive.org/details/apple-hig/MacOSX_HIG_2013_10_22/)