### PR TITLE
Make Options window scrollable

### DIFF
--- a/src/gui/src/settings/options-window.ui
+++ b/src/gui/src/settings/options-window.ui
@@ -195,6 +195,13 @@
        </property>
       </item>
      </widget>
+     <widget class="QScrollArea" name="stackedWidgetScrollArea">
+      <property name="minimumSize">
+        <size>
+          <width>0</width>
+          <height>400</height>
+        </size>
+      </property>
      <widget class="QStackedWidget" name="stackedWidget">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -5979,6 +5986,7 @@
          </spacer>
         </item>
        </layout>
+        </widget>
       </widget>
      </widget>
     </widget>


### PR DESCRIPTION
Should fix #3363.

<details>
<summary>Screenshots</summary>

Before:
![Before](https://github.com/user-attachments/assets/fb387bec-4017-4abf-9467-591baa291daa)

After:
![After](https://github.com/user-attachments/assets/e0eb85f3-865e-4ae1-ad73-82bda6f8bc25)

</details>
