### PR TITLE
Add Chinese Traditional translations

### DIFF
--- a/src/crash-reporter/languages/ChineseTraditional.ts
+++ b/src/crash-reporter/languages/ChineseTraditional.ts
@@ -6,52 +6,52 @@
     <message>
       <location filename="../src/crash-reporter-window.ui" line="14"/>
       <source>Crash Reporter</source>
-      <translation type="unfinished"/>
+      <translation>錯誤報告</translation>
     </message>
     <message>
       <location filename="../src/crash-reporter-window.ui" line="28"/>
       <source>Sorry</source>
-      <translation type="unfinished"/>
+      <translation>抱歉！</translation>
     </message>
     <message>
       <location filename="../src/crash-reporter-window.ui" line="44"/>
       <source>Grabber encountered a problem and crashed. The program will try to restore your tabs and other settings when it restarts.</source>
-      <translation type="unfinished"/>
+      <translation>Grabber 遇到了問題並且停止工作。程序將會在重啟時嘗試恢復您的標籤頁與設置</translation>
     </message>
     <message>
       <location filename="../src/crash-reporter-window.ui" line="60"/>
       <source>To help us fix this crash, you can send us a bug report.</source>
-      <translation type="unfinished"/>
+      <translation>為了幫助我們修復問題，您可以給我們發送錯誤報告</translation>
     </message>
     <message>
       <location filename="../src/crash-reporter-window.ui" line="70"/>
       <source>Send a bug report</source>
-      <translation type="unfinished"/>
+      <translation>發送錯誤報告</translation>
     </message>
     <message>
       <location filename="../src/crash-reporter-window.ui" line="95"/>
       <source>Log</source>
-      <translation type="unfinished"/>
+      <translation>日誌</translation>
     </message>
     <message>
       <location filename="../src/crash-reporter-window.ui" line="102"/>
       <source>Settings</source>
-      <translation type="unfinished"/>
+      <translation>設置</translation>
     </message>
     <message>
       <location filename="../src/crash-reporter-window.ui" line="109"/>
       <source>Dump</source>
-      <translation type="unfinished"/>
+      <translation>轉儲資訊</translation>
     </message>
     <message>
       <location filename="../src/crash-reporter-window.ui" line="155"/>
       <source>Restart</source>
-      <translation type="unfinished"/>
+      <translation>重啟程序</translation>
     </message>
     <message>
       <location filename="../src/crash-reporter-window.ui" line="162"/>
       <source>Quit</source>
-      <translation type="unfinished"/>
+      <translation>退出</translation>
     </message>
   </context>
 </TS>

--- a/src/gui-qml/languages/ChineseTraditional.ts
+++ b/src/gui-qml/languages/ChineseTraditional.ts
@@ -6,58 +6,58 @@
     <message>
       <location filename="../src/components/settings/pages/AboutSettingsPage.qml" line="11"/>
       <source>About</source>
-      <translation type="unfinished"/>
+      <translation>關於</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AboutSettingsPage.qml" line="14"/>
       <source>Version</source>
-      <translation type="unfinished"/>
+      <translation>版本</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AboutSettingsPage.qml" line="21"/>
       <source>Check for updates</source>
-      <translation type="unfinished"/>
+      <translation>檢查更新</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AboutSettingsPage.qml" line="26"/>
       <source>See project on Github</source>
-      <translation type="unfinished"/>
+      <translation>查看 Github 上的項目</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AboutSettingsPage.qml" line="31"/>
       <source>Report an issue</source>
-      <translation type="unfinished"/>
+      <translation>回饋問題</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AboutSettingsPage.qml" line="38"/>
       <source>Author</source>
-      <translation type="unfinished"/>
+      <translation>開發者</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AboutSettingsPage.qml" line="41"/>
       <source>Email</source>
-      <translation type="unfinished"/>
+      <translation>電子信箱</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AboutSettingsPage.qml" line="47"/>
       <location filename="../src/components/settings/pages/AboutSettingsPage.qml" line="70"/>
       <source>Github</source>
-      <translation type="unfinished"/>
+      <translation>Github</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AboutSettingsPage.qml" line="55"/>
       <source>Donate</source>
-      <translation type="unfinished"/>
+      <translation>捐助</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AboutSettingsPage.qml" line="58"/>
       <source>Patreon</source>
-      <translation type="unfinished"/>
+      <translation>Patreon</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AboutSettingsPage.qml" line="64"/>
       <source>Paypal</source>
-      <translation type="unfinished"/>
+      <translation>Paypal</translation>
     </message>
   </context>
   <context>
@@ -65,32 +65,32 @@
     <message>
       <location filename="../src/components/AddSourceScreen.qml" line="24"/>
       <source>Add new source</source>
-      <translation type="unfinished"/>
+      <translation>添加新的來源</translation>
     </message>
     <message>
       <location filename="../src/components/AddSourceScreen.qml" line="34"/>
       <source>Error</source>
-      <translation type="unfinished"/>
+      <translation>錯誤</translation>
     </message>
     <message>
       <location filename="../src/components/AddSourceScreen.qml" line="43"/>
       <source>Type</source>
-      <translation type="unfinished"/>
+      <translation>類型</translation>
     </message>
     <message>
       <location filename="../src/components/AddSourceScreen.qml" line="53"/>
       <source>URL</source>
-      <translation type="unfinished"/>
+      <translation>URL</translation>
     </message>
     <message>
       <location filename="../src/components/AddSourceScreen.qml" line="63"/>
       <source>HTTPS</source>
-      <translation type="unfinished"/>
+      <translation>HTTPS</translation>
     </message>
     <message>
       <location filename="../src/components/AddSourceScreen.qml" line="74"/>
       <source>Add</source>
-      <translation type="unfinished"/>
+      <translation>添加</translation>
     </message>
   </context>
   <context>
@@ -98,72 +98,72 @@
     <message>
       <location filename="../src/components/settings/pages/AdvancedSettingsPage.qml" line="13"/>
       <source>Updates</source>
-      <translation type="unfinished"/>
+      <translation>更新</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AdvancedSettingsPage.qml" line="16"/>
       <source>Check for updates interval</source>
-      <translation type="unfinished"/>
+      <translation>更新檢查間隔</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AdvancedSettingsPage.qml" line="17"/>
       <source>Every time</source>
-      <translation type="unfinished"/>
+      <translation>每次啟動</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AdvancedSettingsPage.qml" line="17"/>
       <source>Once a day</source>
-      <translation type="unfinished"/>
+      <translation>每天</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AdvancedSettingsPage.qml" line="17"/>
       <source>Once a week</source>
-      <translation type="unfinished"/>
+      <translation>每週</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AdvancedSettingsPage.qml" line="17"/>
       <source>Once a month</source>
-      <translation type="unfinished"/>
+      <translation>每月</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AdvancedSettingsPage.qml" line="17"/>
       <source>Never</source>
-      <translation type="unfinished"/>
+      <translation>從不</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AdvancedSettingsPage.qml" line="25"/>
       <source>Backup</source>
-      <translation type="unfinished"/>
+      <translation>備份</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AdvancedSettingsPage.qml" line="28"/>
       <source>Export settings</source>
-      <translation type="unfinished"/>
+      <translation>導出配置</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AdvancedSettingsPage.qml" line="29"/>
       <source>Backup the app settings.ini file on your device.</source>
-      <translation type="unfinished"/>
+      <translation>在您的設備上備份應用程式 settings.ini 文件</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AdvancedSettingsPage.qml" line="37"/>
       <source>Please choose a directory</source>
-      <translation type="unfinished"/>
+      <translation>請選擇一個目錄</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AdvancedSettingsPage.qml" line="44"/>
       <source>Import settings</source>
-      <translation type="unfinished"/>
+      <translation>導入配置</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AdvancedSettingsPage.qml" line="45"/>
       <source>Import the app settings.ini from an existing file.</source>
-      <translation type="unfinished"/>
+      <translation>從現有文件導入應用程式 setting.ini</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AdvancedSettingsPage.qml" line="53"/>
       <source>Please choose a file</source>
-      <translation type="unfinished"/>
+      <translation>請選擇一個文件</translation>
     </message>
   </context>
   <context>
@@ -171,37 +171,37 @@
     <message>
       <location filename="../src/components/settings/pages/AppearanceSettingsPage.qml" line="11"/>
       <source>Appearance</source>
-      <translation type="unfinished"/>
+      <translation>外觀</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AppearanceSettingsPage.qml" line="14"/>
       <source>Theme</source>
-      <translation type="unfinished"/>
+      <translation>主題</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AppearanceSettingsPage.qml" line="21"/>
       <source>Primary color</source>
-      <translation type="unfinished"/>
+      <translation>主體色</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AppearanceSettingsPage.qml" line="26"/>
       <source>Accent color</source>
-      <translation type="unfinished"/>
+      <translation>強調色</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AppearanceSettingsPage.qml" line="33"/>
       <source>Image</source>
-      <translation type="unfinished"/>
+      <translation>圖片</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AppearanceSettingsPage.qml" line="36"/>
       <source>Background color</source>
-      <translation type="unfinished"/>
+      <translation>背景顏色</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AppearanceSettingsPage.qml" line="41"/>
       <source>Tags</source>
-      <translation type="unfinished"/>
+      <translation>標籤</translation>
     </message>
   </context>
   <context>
@@ -209,67 +209,67 @@
     <message>
       <location filename="../src/components/settings/pages/AppearanceTagsSettingsPage.qml" line="11"/>
       <source>Tags</source>
-      <translation type="unfinished"/>
+      <translation>標籤</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AppearanceTagsSettingsPage.qml" line="14"/>
       <source>Artists</source>
-      <translation type="unfinished"/>
+      <translation>藝術家</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AppearanceTagsSettingsPage.qml" line="19"/>
       <source>Circle</source>
-      <translation type="unfinished"/>
+      <translation>社團</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AppearanceTagsSettingsPage.qml" line="24"/>
       <source>Series</source>
-      <translation type="unfinished"/>
+      <translation>系列</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AppearanceTagsSettingsPage.qml" line="29"/>
       <source>Characters</source>
-      <translation type="unfinished"/>
+      <translation>角色</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AppearanceTagsSettingsPage.qml" line="34"/>
       <source>Species</source>
-      <translation type="unfinished"/>
+      <translation>物種 (Species)</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AppearanceTagsSettingsPage.qml" line="39"/>
       <source>Metas</source>
-      <translation type="unfinished"/>
+      <translation>元數據</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AppearanceTagsSettingsPage.qml" line="44"/>
       <source>Models</source>
-      <translation type="unfinished"/>
+      <translation>模型</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AppearanceTagsSettingsPage.qml" line="49"/>
       <source>Generals</source>
-      <translation type="unfinished"/>
+      <translation>一般</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AppearanceTagsSettingsPage.qml" line="54"/>
       <source>Favorites</source>
-      <translation type="unfinished"/>
+      <translation>收藏</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AppearanceTagsSettingsPage.qml" line="59"/>
       <source>Kept for later</source>
-      <translation type="unfinished"/>
+      <translation>等一下再看</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AppearanceTagsSettingsPage.qml" line="64"/>
       <source>Blacklisted</source>
-      <translation type="unfinished"/>
+      <translation>已列入黑名單</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/AppearanceTagsSettingsPage.qml" line="69"/>
       <source>Ignored</source>
-      <translation type="unfinished"/>
+      <translation>已忽略</translation>
     </message>
   </context>
   <context>
@@ -278,57 +278,57 @@
       <location filename="../src/components/settings/pages/BlacklistSettingsPage.qml" line="11"/>
       <location filename="../src/components/settings/pages/BlacklistSettingsPage.qml" line="14"/>
       <source>Blacklist</source>
-      <translation type="unfinished"/>
+      <translation>黑名單</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/BlacklistSettingsPage.qml" line="15"/>
       <source>One line per blacklist. Multiple tags make an 'AND' condition.</source>
-      <translation type="unfinished"/>
+      <translation>每行一個黑名單項。單行多個標籤將視為'每個標籤都包含'時生效。</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/BlacklistSettingsPage.qml" line="20"/>
       <source>Hide blacklisted</source>
-      <translation type="unfinished"/>
+      <translation>隱藏在黑名單中的資源</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/BlacklistSettingsPage.qml" line="21"/>
       <source>Hide blacklisted images from the results.</source>
-      <translation type="unfinished"/>
+      <translation>從結果中隱藏黑名單中的圖像。</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/BlacklistSettingsPage.qml" line="26"/>
       <source>Download blacklisted</source>
-      <translation type="unfinished"/>
+      <translation>下載黑名單中的資源</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/BlacklistSettingsPage.qml" line="27"/>
       <source>Download blacklisted images during batch downloads.</source>
-      <translation type="unfinished"/>
+      <translation>批次下載時下載黑名單中的資源。</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/BlacklistSettingsPage.qml" line="34"/>
       <source>Tagging</source>
-      <translation type="unfinished"/>
+      <translation>標記</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/BlacklistSettingsPage.qml" line="37"/>
       <source>Removed tags</source>
-      <translation type="unfinished"/>
+      <translation>移除標籤</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/BlacklistSettingsPage.qml" line="38"/>
       <source>These won't be taken into account when saving the image.</source>
-      <translation type="unfinished"/>
+      <translation>這些標籤在保存圖片時不會被處理。</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/BlacklistSettingsPage.qml" line="43"/>
       <source>Ignored tags</source>
-      <translation type="unfinished"/>
+      <translation>忽略的標籤</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/BlacklistSettingsPage.qml" line="44"/>
       <source>One per line. Their tag type will be reset to the default.</source>
-      <translation type="unfinished"/>
+      <translation>每行一個標籤。他們的標籤類型將重設為默認標籤。</translation>
     </message>
   </context>
   <context>
@@ -336,7 +336,7 @@
     <message>
       <location filename="../src/components/FavoritesScreen.qml" line="22"/>
       <source>Favorites</source>
-      <translation type="unfinished"/>
+      <translation>收藏</translation>
     </message>
   </context>
   <context>
@@ -344,7 +344,7 @@
     <message>
       <location filename="../src/components/settings/items/FolderSetting.qml" line="29"/>
       <source>Please choose a directory</source>
-      <translation type="unfinished"/>
+      <translation>請選擇一個目錄</translation>
     </message>
   </context>
   <context>
@@ -366,22 +366,22 @@
     <message>
       <location filename="../src/loaders/image-loader.cpp" line="155"/>
       <source>File is too big to be displayed.</source>
-      <translation type="unfinished"/>
+      <translation>文件過大，無法顯示</translation>
     </message>
     <message>
       <location filename="../src/loaders/image-loader.cpp" line="158"/>
       <source>Image not found.</source>
-      <translation type="unfinished"/>
+      <translation>未找到圖片</translation>
     </message>
     <message>
       <location filename="../src/loaders/image-loader.cpp" line="161"/>
       <source>Error loading the image.</source>
-      <translation type="unfinished"/>
+      <translation>載入圖片失敗</translation>
     </message>
     <message>
       <location filename="../src/loaders/image-loader.cpp" line="164"/>
       <source>Error saving the image.</source>
-      <translation type="unfinished"/>
+      <translation>保存圖像時失敗</translation>
     </message>
   </context>
   <context>
@@ -389,7 +389,7 @@
     <message>
       <location filename="../src/components/ImageScreen.qml" line="72"/>
       <source>Image</source>
-      <translation type="unfinished"/>
+      <translation>圖片</translation>
     </message>
   </context>
   <context>
@@ -397,22 +397,22 @@
     <message>
       <location filename="../src/components/settings/pages/InterfaceSettingsPage.qml" line="12"/>
       <source>Interface</source>
-      <translation type="unfinished"/>
+      <translation>界面</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/InterfaceSettingsPage.qml" line="15"/>
       <source>Language</source>
-      <translation type="unfinished"/>
+      <translation>語言</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/InterfaceSettingsPage.qml" line="24"/>
       <source>Search results</source>
-      <translation type="unfinished"/>
+      <translation>搜索結果</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/InterfaceSettingsPage.qml" line="27"/>
       <source>Infinite scroll</source>
-      <translation type="unfinished"/>
+      <translation>無限滾動</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/InterfaceSettingsPage.qml" line="28"/>
@@ -422,47 +422,47 @@
     <message>
       <location filename="../src/components/settings/pages/InterfaceSettingsPage.qml" line="33"/>
       <source>Columns (portrait)</source>
-      <translation type="unfinished"/>
+      <translation>列（縱向）</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/InterfaceSettingsPage.qml" line="40"/>
       <source>Columns (landscape)</source>
-      <translation type="unfinished"/>
+      <translation>列（橫向）</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/InterfaceSettingsPage.qml" line="47"/>
       <source>Layout type</source>
-      <translation type="unfinished"/>
+      <translation>布局類型</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/InterfaceSettingsPage.qml" line="54"/>
       <source>Grid ratio</source>
-      <translation type="unfinished"/>
+      <translation>網格比例</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/InterfaceSettingsPage.qml" line="62"/>
       <source>Thumbnail fill mode</source>
-      <translation type="unfinished"/>
+      <translation>縮圖填充模式</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/InterfaceSettingsPage.qml" line="70"/>
       <source>Spaced grid</source>
-      <translation type="unfinished"/>
+      <translation>間隔網格</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/InterfaceSettingsPage.qml" line="77"/>
       <source>Rounded grid</source>
-      <translation type="unfinished"/>
+      <translation>圓角網格</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/InterfaceSettingsPage.qml" line="78"/>
       <source>Slightly round thumbnails.</source>
-      <translation type="unfinished"/>
+      <translation>圓角縮圖</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/InterfaceSettingsPage.qml" line="85"/>
       <source>Image viewer</source>
-      <translation type="unfinished"/>
+      <translation>圖像查看器</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/InterfaceSettingsPage.qml" line="88"/>
@@ -477,7 +477,7 @@
     <message>
       <location filename="../src/components/settings/pages/InterfaceSettingsPage.qml" line="94"/>
       <source>Buttons at the bottom</source>
-      <translation type="unfinished"/>
+      <translation>底部按鈕</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/InterfaceSettingsPage.qml" line="95"/>
@@ -488,22 +488,22 @@
       <location filename="../src/components/settings/pages/InterfaceSettingsPage.qml" line="102"/>
       <location filename="../src/components/settings/pages/InterfaceSettingsPage.qml" line="105"/>
       <source>Confirm exit</source>
-      <translation type="unfinished"/>
+      <translation>退出時確認</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/InterfaceSettingsPage.qml" line="106"/>
       <source>Show a confirmation dialog before exiting.</source>
-      <translation type="unfinished"/>
+      <translation>關閉前顯示確認對話框。</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/InterfaceSettingsPage.qml" line="111"/>
       <source>Double tap to exit</source>
-      <translation type="unfinished"/>
+      <translation>雙擊按鈕退出</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/InterfaceSettingsPage.qml" line="112"/>
       <source>Tap back button twice to exit.</source>
-      <translation type="unfinished"/>
+      <translation>按兩次返回按鈕退出。</translation>
     </message>
   </context>
   <context>
@@ -512,7 +512,7 @@
       <location filename="../src/components/settings/items/KeyValueSetting.qml" line="63"/>
       <location filename="../src/components/settings/items/KeyValueSetting.qml" line="76"/>
       <source>Add</source>
-      <translation type="unfinished"/>
+      <translation>添加</translation>
     </message>
     <message>
       <location filename="../src/components/settings/items/KeyValueSetting.qml" line="85"/>
@@ -524,12 +524,12 @@
       <location filename="../src/components/settings/items/KeyValueSetting.qml" line="93"/>
       <location filename="../src/components/settings/items/KeyValueSetting.qml" line="122"/>
       <source>Value</source>
-      <translation type="unfinished"/>
+      <translation>值</translation>
     </message>
     <message>
       <location filename="../src/components/settings/items/KeyValueSetting.qml" line="105"/>
       <source>Edit</source>
-      <translation type="unfinished"/>
+      <translation>編輯</translation>
     </message>
   </context>
   <context>
@@ -537,7 +537,7 @@
     <message>
       <location filename="../src/components/LogScreen.qml" line="22"/>
       <source>Log</source>
-      <translation type="unfinished"/>
+      <translation>日誌</translation>
     </message>
   </context>
   <context>
@@ -545,27 +545,27 @@
     <message>
       <location filename="../src/components/MainDrawer.qml" line="106"/>
       <source>Search</source>
-      <translation type="unfinished"/>
+      <translation>搜索</translation>
     </message>
     <message>
       <location filename="../src/components/MainDrawer.qml" line="112"/>
       <source>Favorites</source>
-      <translation type="unfinished"/>
+      <translation>收藏</translation>
     </message>
     <message>
       <location filename="../src/components/MainDrawer.qml" line="118"/>
       <source>Sources</source>
-      <translation type="unfinished"/>
+      <translation>來源</translation>
     </message>
     <message>
       <location filename="../src/components/MainDrawer.qml" line="124"/>
       <source>Log</source>
-      <translation type="unfinished"/>
+      <translation>日誌</translation>
     </message>
     <message>
       <location filename="../src/components/MainDrawer.qml" line="148"/>
       <source>Settings</source>
-      <translation type="unfinished"/>
+      <translation>設置</translation>
     </message>
   </context>
   <context>
@@ -573,42 +573,42 @@
     <message>
       <location filename="../src/components/settings/pages/NetworkSettingsPage.qml" line="11"/>
       <source>Proxy</source>
-      <translation type="unfinished"/>
+      <translation>代理</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/NetworkSettingsPage.qml" line="14"/>
       <source>Enable proxy</source>
-      <translation type="unfinished"/>
+      <translation>啟用代理</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/NetworkSettingsPage.qml" line="19"/>
       <source>Use system-wide proxy settings</source>
-      <translation type="unfinished"/>
+      <translation>使用系統代理</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/NetworkSettingsPage.qml" line="25"/>
       <source>Type</source>
-      <translation type="unfinished"/>
+      <translation>類型</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/NetworkSettingsPage.qml" line="33"/>
       <source>Host</source>
-      <translation type="unfinished"/>
+      <translation>主機</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/NetworkSettingsPage.qml" line="39"/>
       <source>Port</source>
-      <translation type="unfinished"/>
+      <translation>埠</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/NetworkSettingsPage.qml" line="46"/>
       <source>Username</source>
-      <translation type="unfinished"/>
+      <translation>使用者名稱</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/NetworkSettingsPage.qml" line="52"/>
       <source>Password</source>
-      <translation type="unfinished"/>
+      <translation>密碼</translation>
     </message>
   </context>
   <context>
@@ -618,90 +618,90 @@
       <location filename="../src/components/settings/pages/SaveSettingsPage.qml" line="46"/>
       <location filename="../src/components/settings/pages/SaveSettingsPage.qml" line="53"/>
       <source>Save</source>
-      <translation type="unfinished"/>
+      <translation>保存</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/SaveSettingsPage.qml" line="14"/>
       <source>Folder</source>
-      <translation type="unfinished"/>
+      <translation>文件夾</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/SaveSettingsPage.qml" line="19"/>
       <source>Filename</source>
-      <translation type="unfinished"/>
+      <translation>檔案名</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/SaveSettingsPage.qml" line="24"/>
       <source>Tags separator</source>
-      <translation type="unfinished"/>
+      <translation>標籤分隔符號</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/SaveSettingsPage.qml" line="29"/>
       <source>Replace spaces by underscores</source>
-      <translation type="unfinished"/>
+      <translation>用下劃線代替空格</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/SaveSettingsPage.qml" line="34"/>
       <source>Replace JPEG by JPG</source>
-      <translation type="unfinished"/>
+      <translation>替換 JPEG 為 JPG</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/SaveSettingsPage.qml" line="35"/>
       <source>If the image's extension is ".jpeg", it will be replaced by ".jpg".</source>
-      <translation type="unfinished"/>
+      <translation>如果圖像的副檔名是".jpeg"，它將被替換成".jpg"。</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/SaveSettingsPage.qml" line="42"/>
       <source>Duplicate management</source>
-      <translation type="unfinished"/>
+      <translation>重複項管理</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/SaveSettingsPage.qml" line="45"/>
       <source>If a file already exists globally</source>
-      <translation type="unfinished"/>
+      <translation>如果文件已經被下載過</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/SaveSettingsPage.qml" line="46"/>
       <location filename="../src/components/settings/pages/SaveSettingsPage.qml" line="53"/>
       <source>Copy</source>
-      <translation type="unfinished"/>
+      <translation>複製</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/SaveSettingsPage.qml" line="46"/>
       <location filename="../src/components/settings/pages/SaveSettingsPage.qml" line="53"/>
       <source>Move</source>
-      <translation type="unfinished"/>
+      <translation>移動</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/SaveSettingsPage.qml" line="46"/>
       <location filename="../src/components/settings/pages/SaveSettingsPage.qml" line="53"/>
       <source>Don't save</source>
-      <translation type="unfinished"/>
+      <translation>不要保存</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/SaveSettingsPage.qml" line="52"/>
       <source>If it's in the same directory</source>
-      <translation type="unfinished"/>
+      <translation>如果文件在同一個目錄中</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/SaveSettingsPage.qml" line="59"/>
       <source>Keep deleted files in the MD5 list</source>
-      <translation type="unfinished"/>
+      <translation>保留已刪除的文件的 MD5</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/SaveSettingsPage.qml" line="66"/>
       <source>Tags</source>
-      <translation type="unfinished"/>
+      <translation>標籤</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/SaveSettingsPage.qml" line="71"/>
       <source>General</source>
-      <translation type="unfinished"/>
+      <translation>一般</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/SaveSettingsPage.qml" line="79"/>
       <source>Artist</source>
-      <translation type="unfinished"/>
+      <translation>藝術家</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/SaveSettingsPage.qml" line="87"/>
@@ -748,7 +748,7 @@
     <message>
       <location filename="../src/components/SearchScreen.qml" line="69"/>
       <source>Search...</source>
-      <translation type="unfinished"/>
+      <translation>搜索...</translation>
     </message>
     <message>
       <location filename="../src/components/SearchScreen.qml" line="217"/>
@@ -767,47 +767,47 @@
     <message>
       <location filename="../src/components/settings/SettingsScreen.qml" line="31"/>
       <source>Settings</source>
-      <translation type="unfinished"/>
+      <translation>設置</translation>
     </message>
     <message>
       <location filename="../src/components/settings/SettingsScreen.qml" line="49"/>
       <source>Interface</source>
-      <translation type="unfinished"/>
+      <translation>界面</translation>
     </message>
     <message>
       <location filename="../src/components/settings/SettingsScreen.qml" line="54"/>
       <source>Appearance</source>
-      <translation type="unfinished"/>
+      <translation>外觀</translation>
     </message>
     <message>
       <location filename="../src/components/settings/SettingsScreen.qml" line="59"/>
       <source>Save</source>
-      <translation type="unfinished"/>
+      <translation>保存</translation>
     </message>
     <message>
       <location filename="../src/components/settings/SettingsScreen.qml" line="64"/>
       <source>Sources</source>
-      <translation type="unfinished"/>
+      <translation>來源</translation>
     </message>
     <message>
       <location filename="../src/components/settings/SettingsScreen.qml" line="69"/>
       <source>Blacklist</source>
-      <translation type="unfinished"/>
+      <translation>黑名單</translation>
     </message>
     <message>
       <location filename="../src/components/settings/SettingsScreen.qml" line="74"/>
       <source>Network</source>
-      <translation type="unfinished"/>
+      <translation>網路</translation>
     </message>
     <message>
       <location filename="../src/components/settings/SettingsScreen.qml" line="79"/>
       <source>Advanced</source>
-      <translation type="unfinished"/>
+      <translation>進階設定</translation>
     </message>
     <message>
       <location filename="../src/components/settings/SettingsScreen.qml" line="84"/>
       <source>About</source>
-      <translation type="unfinished"/>
+      <translation>關於</translation>
     </message>
   </context>
   <context>
@@ -815,97 +815,97 @@
     <message>
       <location filename="../src/components/settings/SourceSettingsScreen.qml" line="81"/>
       <source>General</source>
-      <translation type="unfinished"/>
+      <translation>全局</translation>
     </message>
     <message>
       <location filename="../src/components/settings/SourceSettingsScreen.qml" line="84"/>
       <source>Name</source>
-      <translation type="unfinished"/>
+      <translation>名稱</translation>
     </message>
     <message>
       <location filename="../src/components/settings/SourceSettingsScreen.qml" line="93"/>
       <source>HTTPS</source>
-      <translation type="unfinished"/>
+      <translation>HTTPS</translation>
     </message>
     <message>
       <location filename="../src/components/settings/SourceSettingsScreen.qml" line="94"/>
       <source>Use a secure connection.</source>
-      <translation type="unfinished"/>
+      <translation>使用安全連接（https）</translation>
     </message>
     <message>
       <location filename="../src/components/settings/SourceSettingsScreen.qml" line="105"/>
       <source>Login</source>
-      <translation type="unfinished"/>
+      <translation>登錄</translation>
     </message>
     <message>
       <location filename="../src/components/settings/SourceSettingsScreen.qml" line="114"/>
       <source>Type</source>
-      <translation type="unfinished"/>
+      <translation>類型</translation>
     </message>
     <message>
       <location filename="../src/components/settings/SourceSettingsScreen.qml" line="154"/>
       <source>API order</source>
-      <translation type="unfinished"/>
+      <translation>API 順序</translation>
     </message>
     <message>
       <location filename="../src/components/settings/SourceSettingsScreen.qml" line="163"/>
       <source>Use default API order</source>
-      <translation type="unfinished"/>
+      <translation>使用默認 API 順序</translation>
     </message>
     <message>
       <location filename="../src/components/settings/SourceSettingsScreen.qml" line="168"/>
       <source>Source 1</source>
-      <translation type="unfinished"/>
+      <translation>來源 1</translation>
     </message>
     <message>
       <location filename="../src/components/settings/SourceSettingsScreen.qml" line="180"/>
       <source>Source 2</source>
-      <translation type="unfinished"/>
+      <translation>來源 2</translation>
     </message>
     <message>
       <location filename="../src/components/settings/SourceSettingsScreen.qml" line="192"/>
       <source>Source 3</source>
-      <translation type="unfinished"/>
+      <translation>來源 3</translation>
     </message>
     <message>
       <location filename="../src/components/settings/SourceSettingsScreen.qml" line="204"/>
       <source>Source 4</source>
-      <translation type="unfinished"/>
+      <translation>來源 4</translation>
     </message>
     <message>
       <location filename="../src/components/settings/SourceSettingsScreen.qml" line="218"/>
       <source>Download</source>
-      <translation type="unfinished"/>
+      <translation>何時下載原圖</translation>
     </message>
     <message>
       <location filename="../src/components/settings/SourceSettingsScreen.qml" line="232"/>
       <source>Interval (image)</source>
-      <translation type="unfinished"/>
+      <translation>時間間隔（請求圖片）</translation>
     </message>
     <message>
       <location filename="../src/components/settings/SourceSettingsScreen.qml" line="242"/>
       <source>Interval (page)</source>
-      <translation type="unfinished"/>
+      <translation>時間間隔（請求頁面）</translation>
     </message>
     <message>
       <location filename="../src/components/settings/SourceSettingsScreen.qml" line="252"/>
       <source>Interval (details)</source>
-      <translation type="unfinished"/>
+      <translation>時間間隔（請求圖片詳情）</translation>
     </message>
     <message>
       <location filename="../src/components/settings/SourceSettingsScreen.qml" line="262"/>
       <source>Interval (error)</source>
-      <translation type="unfinished"/>
+      <translation>時間間隔（發生錯誤）</translation>
     </message>
     <message>
       <location filename="../src/components/settings/SourceSettingsScreen.qml" line="274"/>
       <source>Cookies</source>
-      <translation type="unfinished"/>
+      <translation>Cookies</translation>
     </message>
     <message>
       <location filename="../src/components/settings/SourceSettingsScreen.qml" line="301"/>
       <source>Headers</source>
-      <translation type="unfinished"/>
+      <translation>請求頭部</translation>
     </message>
   </context>
   <context>
@@ -913,7 +913,7 @@
     <message>
       <location filename="../src/components/SourcesScreen.qml" line="31"/>
       <source>Sources selection</source>
-      <translation type="unfinished"/>
+      <translation>自動探測來源</translation>
     </message>
   </context>
   <context>
@@ -921,27 +921,27 @@
     <message>
       <location filename="../src/components/settings/pages/SourcesSettingsPage.qml" line="11"/>
       <source>API order</source>
-      <translation type="unfinished"/>
+      <translation>API 順序</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/SourcesSettingsPage.qml" line="14"/>
       <source>Source 1</source>
-      <translation type="unfinished"/>
+      <translation>來源 1</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/SourcesSettingsPage.qml" line="21"/>
       <source>Source 2</source>
-      <translation type="unfinished"/>
+      <translation>來源 2</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/SourcesSettingsPage.qml" line="28"/>
       <source>Source 3</source>
-      <translation type="unfinished"/>
+      <translation>來源 3</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/SourcesSettingsPage.qml" line="35"/>
       <source>Source 4</source>
-      <translation type="unfinished"/>
+      <translation>來源 4</translation>
     </message>
   </context>
   <context>
@@ -949,22 +949,22 @@
     <message>
       <location filename="../src/components/settings/pages/TagSaveSettingsPage.qml" line="17"/>
       <source>If empty</source>
-      <translation type="unfinished"/>
+      <translation>如果為空</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/TagSaveSettingsPage.qml" line="25"/>
       <source>Separator</source>
-      <translation type="unfinished"/>
+      <translation>分割器</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/TagSaveSettingsPage.qml" line="33"/>
       <source>Sort</source>
-      <translation type="unfinished"/>
+      <translation>排序</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/TagSaveSettingsPage.qml" line="43"/>
       <source>If more than n tags</source>
-      <translation type="unfinished"/>
+      <translation>如果多餘 n 個標籤</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/TagSaveSettingsPage.qml" line="57"/>
@@ -975,22 +975,22 @@
       <location filename="../src/components/settings/pages/TagSaveSettingsPage.qml" line="64"/>
       <location filename="../src/components/settings/pages/TagSaveSettingsPage.qml" line="73"/>
       <source>Keep n tags</source>
-      <translation type="unfinished"/>
+      <translation>保留 n 個標籤</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/TagSaveSettingsPage.qml" line="82"/>
       <source>Then add</source>
-      <translation type="unfinished"/>
+      <translation>然後添加</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/TagSaveSettingsPage.qml" line="91"/>
       <source>Replace all tags by</source>
-      <translation type="unfinished"/>
+      <translation>用 ... 替換所有標籤</translation>
     </message>
     <message>
       <location filename="../src/components/settings/pages/TagSaveSettingsPage.qml" line="101"/>
       <source>Use shortest if possible</source>
-      <translation type="unfinished"/>
+      <translation>盡量縮短</translation>
     </message>
   </context>
   <context>
@@ -998,17 +998,17 @@
     <message>
       <location filename="../src/components/TagView.qml" line="21"/>
       <source>Remove from favorites</source>
-      <translation type="unfinished"/>
+      <translation>從收藏移除</translation>
     </message>
     <message>
       <location filename="../src/components/TagView.qml" line="21"/>
       <source>Add to favorites</source>
-      <translation type="unfinished"/>
+      <translation>添加到收藏</translation>
     </message>
     <message>
       <location filename="../src/components/TagView.qml" line="34"/>
       <source>Copy tag</source>
-      <translation type="unfinished"/>
+      <translation>複製標籤</translation>
     </message>
   </context>
   <context>
@@ -1016,27 +1016,27 @@
     <message>
       <location filename="../src/main-screen.qml" line="48"/>
       <source>General</source>
-      <translation type="unfinished"/>
+      <translation>全局</translation>
     </message>
     <message>
       <location filename="../src/main-screen.qml" line="49"/>
       <source>Artist</source>
-      <translation type="unfinished"/>
+      <translation>藝術家</translation>
     </message>
     <message>
       <location filename="../src/main-screen.qml" line="50"/>
       <source>Copyright</source>
-      <translation type="unfinished"/>
+      <translation>系列</translation>
     </message>
     <message>
       <location filename="../src/main-screen.qml" line="51"/>
       <source>Character</source>
-      <translation type="unfinished"/>
+      <translation>角色</translation>
     </message>
     <message>
       <location filename="../src/main-screen.qml" line="52"/>
       <source>Model</source>
-      <translation type="unfinished"/>
+      <translation>模型</translation>
     </message>
     <message>
       <location filename="../src/main-screen.qml" line="53"/>
@@ -1046,82 +1046,82 @@
     <message>
       <location filename="../src/main-screen.qml" line="54"/>
       <source>Species</source>
-      <translation type="unfinished"/>
+      <translation>物種 (Species)</translation>
     </message>
     <message>
       <location filename="../src/main-screen.qml" line="55"/>
       <source>Meta</source>
-      <translation type="unfinished"/>
+      <translation>元資訊 (Meta)</translation>
     </message>
     <message>
       <location filename="../src/main-screen.qml" line="58"/>
       <source>Through URL</source>
-      <translation type="unfinished"/>
+      <translation>通過 url</translation>
     </message>
     <message>
       <location filename="../src/main-screen.qml" line="59"/>
       <source>HTTP Basic</source>
-      <translation type="unfinished"/>
+      <translation>HTTP 基本驗證</translation>
     </message>
     <message>
       <location filename="../src/main-screen.qml" line="60"/>
       <source>GET</source>
-      <translation type="unfinished"/>
+      <translation>GET</translation>
     </message>
     <message>
       <location filename="../src/main-screen.qml" line="61"/>
       <source>POST</source>
-      <translation type="unfinished"/>
+      <translation>POST</translation>
     </message>
     <message>
       <location filename="../src/main-screen.qml" line="62"/>
       <source>OAuth 1</source>
-      <translation type="unfinished"/>
+      <translation>OAuth 1</translation>
     </message>
     <message>
       <location filename="../src/main-screen.qml" line="63"/>
       <source>OAuth 2</source>
-      <translation type="unfinished"/>
+      <translation>OAuth 2</translation>
     </message>
     <message>
       <location filename="../src/main-screen.qml" line="66"/>
       <source>Username</source>
-      <translation type="unfinished"/>
+      <translation>使用者名稱</translation>
     </message>
     <message>
       <location filename="../src/main-screen.qml" line="67"/>
       <source>User ID</source>
-      <translation type="unfinished"/>
+      <translation>用戶 ID</translation>
     </message>
     <message>
       <location filename="../src/main-screen.qml" line="68"/>
       <source>Password</source>
-      <translation type="unfinished"/>
+      <translation>密碼</translation>
     </message>
     <message>
       <location filename="../src/main-screen.qml" line="69"/>
       <source>Salt</source>
-      <translation type="unfinished"/>
+      <translation>鹽值</translation>
     </message>
     <message>
       <location filename="../src/main-screen.qml" line="70"/>
       <source>API key</source>
-      <translation type="unfinished"/>
+      <translation>API 金鑰</translation>
     </message>
     <message>
       <location filename="../src/main-screen.qml" line="88"/>
       <source>Update available</source>
-      <translation type="unfinished"/>
+      <translation>可用更新</translation>
     </message>
     <message>
       <location filename="../src/main-screen.qml" line="157"/>
       <source>Do you want to exit?</source>
-      <translation type="unfinished"/>
+      <translation>您是否想要退出？</translation>
     </message>
     <message>
       <location filename="../src/main-screen.qml" line="171"/>
       <source>Don't ask again</source>
-      <translation type="unfinished"/>
+      <translation>不再顯示</translation>
     </message>
   </context>
 </TS>

--- a/src/languages/ChineseTraditional.ts
+++ b/src/languages/ChineseTraditional.ts
@@ -6,17 +6,17 @@
     <message>
       <location filename="../gui/src/about-window.ui" line="20"/>
       <source>About Grabber</source>
-      <translation type="unfinished"/>
+      <translation>關於 Grabber</translation>
     </message>
     <message>
       <location filename="../gui/src/about-window.ui" line="63"/>
       <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Grabber is a Bionus' creation.&lt;br/&gt;Please visit the &lt;a href="{website}"&gt;&lt;span style=" text-decoration: underline; color:#0000ff;"&gt;site&lt;/span&gt;&lt;/a&gt; to stay updated, or retrieve site or translations files.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-      <translation type="unfinished"/>
+      <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Grabber 是一個由 Bionus 開發的軟體。&lt;br/&gt;請查看 &lt;a href="{website}"&gt;&lt;span style=" text-decoration: underline; color:#0000ff;"&gt;軟體官網&lt;/span&gt;&lt;/a&gt; 來保持軟體或站點和翻譯文件處在最新狀態。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
       <location filename="../gui/src/about-window.ui" line="79"/>
       <source>Special thanks to all contributors for their help improving the program over the years, be it by providing to the code, translations, or reporting issues and suggesting new features.</source>
-      <translation type="unfinished"/>
+      <translation>特別感謝所有貢獻者多年來對改進程序提供的幫助，無論是貢獻代碼、翻譯，還是回報問題和建議新功能。</translation>
     </message>
     <message>
       <location filename="../gui/src/about-window.ui" line="89"/>
@@ -26,12 +26,12 @@
     <message>
       <location filename="../gui/src/about-window.cpp" line="43"/>
       <source>A new version is available: %1</source>
-      <translation type="unfinished"/>
+      <translation>有新版本可用：%1</translation>
     </message>
     <message>
       <location filename="../gui/src/about-window.cpp" line="43"/>
       <source>Grabber is up to date</source>
-      <translation type="unfinished"/>
+      <translation>Grabber 已經是最新版本</translation>
     </message>
   </context>
   <context>
@@ -39,42 +39,42 @@
     <message>
       <location filename="../gui/src/batch/add-group-window.ui" line="14"/>
       <source>Add group</source>
-      <translation type="unfinished"/>
+      <translation>添加到組</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/add-group-window.ui" line="23"/>
       <source>Site</source>
-      <translation type="unfinished"/>
+      <translation>站點</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/add-group-window.ui" line="33"/>
       <source>Tags</source>
-      <translation type="unfinished"/>
+      <translation>標籤</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/add-group-window.ui" line="40"/>
       <source>Page</source>
-      <translation type="unfinished"/>
+      <translation>頁面</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/add-group-window.ui" line="57"/>
       <source>Images per page</source>
-      <translation type="unfinished"/>
+      <translation>每頁圖片數</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/add-group-window.ui" line="77"/>
       <source>Images limit</source>
-      <translation type="unfinished"/>
+      <translation>圖片數限制</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/add-group-window.ui" line="97"/>
       <source>Download images with blacklisted tags</source>
-      <translation type="unfinished"/>
+      <translation>下載圖片（即使包含黑名單中的標籤）</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/add-group-window.ui" line="127"/>
       <source>Post-filtering</source>
-      <translation type="unfinished"/>
+      <translation>後過濾</translation>
     </message>
   </context>
   <context>
@@ -82,63 +82,63 @@
     <message>
       <location filename="../gui/src/batch/add-unique-window.ui" line="14"/>
       <source>Add an image</source>
-      <translation type="unfinished"/>
+      <translation>添加一張圖片</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/add-unique-window.ui" line="103"/>
       <source>Add</source>
-      <translation type="unfinished"/>
+      <translation>添加</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/add-unique-window.ui" line="23"/>
       <source>Site</source>
-      <translation type="unfinished"/>
+      <translation>站點</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/add-unique-window.ui" line="33"/>
       <source>Id</source>
-      <translation type="unfinished"/>
+      <translation>Id</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/add-unique-window.ui" line="40"/>
       <source>Md5</source>
-      <translation type="unfinished"/>
+      <translation>Md5</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/add-unique-window.ui" line="68"/>
       <source>Filename</source>
-      <translation type="unfinished"/>
+      <translation>檔案名</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/add-unique-window.ui" line="138"/>
       <source>One ID per line.</source>
-      <translation type="unfinished"/>
+      <translation>每行一個ID</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/add-unique-window.ui" line="155"/>
       <location filename="../gui/src/batch/add-unique-window.ui" line="215"/>
       <source>+</source>
-      <translation type="unfinished"/>
+      <translation>+</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/add-unique-window.ui" line="198"/>
       <source>One MD5 per line.</source>
-      <translation type="unfinished"/>
+      <translation>每行一個 MD5</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/add-unique-window.ui" line="47"/>
       <source>Folder</source>
-      <translation type="unfinished"/>
+      <translation>文件夾</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/add-unique-window.ui" line="59"/>
       <source>Browse</source>
-      <translation type="unfinished"/>
+      <translation>瀏覽</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/add-unique-window.cpp" line="82"/>
       <source>Choose a save folder</source>
-      <translation type="unfinished"/>
+      <translation>選擇保存的文件夾</translation>
     </message>
   </context>
   <context>
@@ -146,32 +146,32 @@
     <message>
       <location filename="../gui/src/batch/batch-window.ui" line="20"/>
       <source>Batch download</source>
-      <translation type="unfinished"/>
+      <translation>下載隊列</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/batch-window.ui" line="84"/>
       <source>Batch</source>
-      <translation type="unfinished"/>
+      <translation>隊列</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/batch-window.ui" line="89"/>
       <source>Url</source>
-      <translation type="unfinished"/>
+      <translation>Url</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/batch-window.ui" line="94"/>
       <source>Filesize</source>
-      <translation type="unfinished"/>
+      <translation>檔案大小</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/batch-window.ui" line="99"/>
       <source>Speed</source>
-      <translation type="unfinished"/>
+      <translation>下載速度</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/batch-window.ui" line="104"/>
       <source>Progress</source>
-      <translation type="unfinished"/>
+      <translation>進度</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/batch-window.ui" line="114"/>
@@ -181,107 +181,107 @@
     <message>
       <location filename="../gui/src/batch/batch-window.ui" line="121"/>
       <source>Copy links to clipboard</source>
-      <translation type="unfinished"/>
+      <translation>複製連結到剪貼簿</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/batch-window.ui" line="132"/>
       <source>When the download is finished</source>
-      <translation type="unfinished"/>
+      <translation>下載完成時</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/batch-window.ui" line="140"/>
       <source>Do nothing</source>
-      <translation type="unfinished"/>
+      <translation>什麼都不做</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/batch-window.ui" line="145"/>
       <source>Close window</source>
-      <translation type="unfinished"/>
+      <translation>關閉窗口</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/batch-window.ui" line="150"/>
       <source>Open CD tray</source>
-      <translation type="unfinished"/>
+      <translation>彈出光碟機</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/batch-window.ui" line="155"/>
       <source>Open destination folder</source>
-      <translation type="unfinished"/>
+      <translation>打開目標文件夾</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/batch-window.ui" line="160"/>
       <source>Play a sound</source>
-      <translation type="unfinished"/>
+      <translation>播放提示音</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/batch-window.ui" line="165"/>
       <source>Shutdown</source>
-      <translation type="unfinished"/>
+      <translation>關機</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/batch-window.ui" line="173"/>
       <source>Remove</source>
-      <translation type="unfinished"/>
+      <translation>移除</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/batch-window.ui" line="185"/>
       <source>Details</source>
-      <translation type="unfinished"/>
+      <translation>詳情</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/batch-window.ui" line="211"/>
       <location filename="../gui/src/batch/batch-window.cpp" line="93"/>
       <source>Pause</source>
-      <translation type="unfinished"/>
+      <translation>暫停</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/batch-window.ui" line="218"/>
       <source>Skip</source>
-      <translation type="unfinished"/>
+      <translation>跳過</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/batch-window.ui" line="225"/>
       <location filename="../gui/src/batch/batch-window.cpp" line="133"/>
       <source>Cancel</source>
-      <translation type="unfinished"/>
+      <translation>取消</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/batch-window.cpp" line="92"/>
       <source>Paused</source>
-      <translation type="unfinished"/>
+      <translation>已暫停</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/batch-window.cpp" line="93"/>
       <source>Resume</source>
-      <translation type="unfinished"/>
+      <translation>恢復</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/batch-window.cpp" line="395"/>
       <location filename="../gui/src/batch/batch-window.cpp" line="396"/>
       <source>h 'h' m 'm' s 's'</source>
-      <translation type="unfinished"/>
+      <translation>h 'h' m 'm' s 's'</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/batch-window.cpp" line="395"/>
       <location filename="../gui/src/batch/batch-window.cpp" line="396"/>
       <source>m 'm' s 's'</source>
-      <translation type="unfinished"/>
+      <translation>m 'm' s 's'</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/batch-window.cpp" line="395"/>
       <location filename="../gui/src/batch/batch-window.cpp" line="396"/>
       <source>s 's'</source>
-      <translation type="unfinished"/>
+      <translation>s 's'</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/batch-window.cpp" line="399"/>
       <source>&lt;b&gt;Average speed:&lt;/b&gt; %1 %2&lt;br/&gt;&lt;br/&gt;&lt;b&gt;Elapsed time:&lt;/b&gt; %3&lt;br/&gt;&lt;b&gt;Remaining time:&lt;/b&gt; %4</source>
-      <translation type="unfinished"/>
+      <translation>&lt;b&gt;平均速度: &lt;/b&gt; %1 %2&lt;br/&gt;&lt;br/&gt;&lt;b&gt;已用時間: &lt;/b&gt; %3&lt;br/&gt;&lt;b&gt;剩餘時間: &lt;/b&gt; %4</translation>
     </message>
     <message>
       <location filename="../gui/src/batch/batch-window.cpp" line="429"/>
       <source>Close</source>
-      <translation type="unfinished"/>
+      <translation>關閉</translation>
     </message>
   </context>
   <context>
@@ -290,67 +290,69 @@
       <location filename="../gui/src/utils/blacklist-fix/blacklist-fix-1.ui" line="14"/>
       <location filename="../gui/src/utils/blacklist-fix/blacklist-fix-1.cpp" line="94"/>
       <source>Blacklist fixer</source>
-      <translation type="unfinished"/>
+      <translation>黑名單修復</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/blacklist-fix/blacklist-fix-1.ui" line="24"/>
       <source>Folder</source>
-      <translation type="unfinished"/>
+      <translation>文件夾</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/blacklist-fix/blacklist-fix-1.ui" line="34"/>
       <source>Force md5 calculation</source>
-      <translation type="unfinished"/>
+      <translation>強制進行 md5 計算</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/blacklist-fix/blacklist-fix-1.ui" line="41"/>
       <source>Get md5 in filename</source>
-      <translation type="unfinished"/>
+      <translation>通過檔案名獲取 md5</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/blacklist-fix/blacklist-fix-1.ui" line="51"/>
       <source>Filename</source>
-      <translation type="unfinished"/>
+      <translation>檔案名</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/blacklist-fix/blacklist-fix-1.ui" line="115"/>
       <source>Blacklist</source>
-      <translation type="unfinished"/>
+      <translation>黑名單</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/blacklist-fix/blacklist-fix-1.ui" line="61"/>
       <source>Source</source>
-      <translation type="unfinished"/>
+      <translation>來源</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/blacklist-fix/blacklist-fix-1.ui" line="74"/>
       <source>%v/%m</source>
-      <translation type="unfinished"/>
+      <translation>%v/%m</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/blacklist-fix/blacklist-fix-1.ui" line="96"/>
       <source>Continue</source>
-      <translation type="unfinished"/>
+      <translation>繼續</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/blacklist-fix/blacklist-fix-1.ui" line="103"/>
       <source>Cancel</source>
-      <translation type="unfinished"/>
+      <translation>取消</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/blacklist-fix/blacklist-fix-1.cpp" line="56"/>
       <source>This directory does not exist.</source>
-      <translation type="unfinished"/>
+      <translation>這個目錄不存在。</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/blacklist-fix/blacklist-fix-1.cpp" line="63"/>
       <source>If you want to get the MD5 from the filename, you have to include the %md5% token in it.</source>
-      <translation type="unfinished"/>
+      <translation>如果你想要從檔案名獲得 MD5，你必須先添加 %md5% 變數到檔案名中。</translation>
     </message>
     <message numerus="yes">
       <location filename="../gui/src/utils/blacklist-fix/blacklist-fix-1.cpp" line="94"/>
       <source>You are about to download information from %n image(s). Are you sure you want to continue?</source>
-      <translation type="unfinished"/>
+      <translation>
+        <numerusform>你將要下載 %n 張圖片的資訊。你確定要繼續嗎？</numerusform>
+      </translation>
     </message>
   </context>
   <context>
@@ -358,42 +360,42 @@
     <message>
       <location filename="../gui/src/utils/blacklist-fix/blacklist-fix-2.ui" line="14"/>
       <source>Blacklist fixer</source>
-      <translation type="unfinished"/>
+      <translation>黑名單修復</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/blacklist-fix/blacklist-fix-2.ui" line="24"/>
       <source>Choose images to delete in the list below.</source>
-      <translation type="unfinished"/>
+      <translation>在下面的列表中選擇需要刪除的圖片。</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/blacklist-fix/blacklist-fix-2.ui" line="52"/>
       <source>Thumbnail</source>
-      <translation type="unfinished"/>
+      <translation>縮圖</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/blacklist-fix/blacklist-fix-2.ui" line="57"/>
       <source>Name</source>
-      <translation type="unfinished"/>
+      <translation>名稱</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/blacklist-fix/blacklist-fix-2.ui" line="62"/>
       <source>Tag</source>
-      <translation type="unfinished"/>
+      <translation>標籤</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/blacklist-fix/blacklist-fix-2.ui" line="72"/>
       <source>Select found images</source>
-      <translation type="unfinished"/>
+      <translation>選擇所有找到的圖片</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/blacklist-fix/blacklist-fix-2.ui" line="92"/>
       <source>Ok</source>
-      <translation type="unfinished"/>
+      <translation>確定</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/blacklist-fix/blacklist-fix-2.ui" line="99"/>
       <source>Cancel</source>
-      <translation type="unfinished"/>
+      <translation>取消</translation>
     </message>
   </context>
   <context>
@@ -401,37 +403,37 @@
     <message>
       <location filename="../gui/src/settings/condition-window.ui" line="17"/>
       <source>Add a conditional filename</source>
-      <translation type="unfinished"/>
+      <translation>添加一個條件檔案名</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/condition-window.ui" line="32"/>
       <source>You can either use a token or tags as a condition.</source>
-      <translation type="unfinished"/>
+      <translation>你可以使用變數或標籤作為條件。</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/condition-window.ui" line="39"/>
       <source>Condition</source>
-      <translation type="unfinished"/>
+      <translation>條件</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/condition-window.ui" line="49"/>
       <source>Filename</source>
-      <translation type="unfinished"/>
+      <translation>檔案名</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/condition-window.ui" line="69"/>
       <source>Folder</source>
-      <translation type="unfinished"/>
+      <translation>文件夾</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/condition-window.ui" line="81"/>
       <source>Leave empty to use the default folder.</source>
-      <translation type="unfinished"/>
+      <translation>留空將使用默認文件夾。</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/condition-window.ui" line="96"/>
       <source>Leave empty to use the default filename.</source>
-      <translation type="unfinished"/>
+      <translation>留空將使用默認檔案名。</translation>
     </message>
   </context>
   <context>
@@ -439,22 +441,22 @@
     <message>
       <location filename="../gui/src/settings/custom-window.ui" line="17"/>
       <source>Add a custom token</source>
-      <translation type="unfinished"/>
+      <translation>添加自訂變數</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/custom-window.ui" line="32"/>
       <source>Separate tags by spaces or line breaks</source>
-      <translation type="unfinished"/>
+      <translation>通過空格或換行分隔標籤</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/custom-window.ui" line="39"/>
       <source>Name</source>
-      <translation type="unfinished"/>
+      <translation>名稱</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/custom-window.ui" line="49"/>
       <source>Tags</source>
-      <translation type="unfinished"/>
+      <translation>標籤</translation>
     </message>
   </context>
   <context>
@@ -462,12 +464,12 @@
     <message>
       <location filename="../gui/src/viewer/details-window.ui" line="17"/>
       <source>Details</source>
-      <translation type="unfinished"/>
+      <translation>詳情</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/details-window.ui" line="46"/>
       <source>Close</source>
-      <translation type="unfinished"/>
+      <translation>關閉</translation>
     </message>
   </context>
   <context>
@@ -475,72 +477,72 @@
     <message>
       <location filename="../gui/src/download-group-table-model.cpp" line="41"/>
       <source>Tags</source>
-      <translation type="unfinished"/>
+      <translation>標籤</translation>
     </message>
     <message>
       <location filename="../gui/src/download-group-table-model.cpp" line="42"/>
       <source>Source</source>
-      <translation type="unfinished"/>
+      <translation>來源</translation>
     </message>
     <message>
       <location filename="../gui/src/download-group-table-model.cpp" line="43"/>
       <source>Page</source>
-      <translation type="unfinished"/>
+      <translation>頁面</translation>
     </message>
     <message>
       <location filename="../gui/src/download-group-table-model.cpp" line="44"/>
       <source>Images per page</source>
-      <translation type="unfinished"/>
+      <translation>每頁圖片數</translation>
     </message>
     <message>
       <location filename="../gui/src/download-group-table-model.cpp" line="45"/>
       <source>Images limit</source>
-      <translation type="unfinished"/>
+      <translation>圖片數限制</translation>
     </message>
     <message>
       <location filename="../gui/src/download-group-table-model.cpp" line="46"/>
       <source>Filename</source>
-      <translation type="unfinished"/>
+      <translation>檔案名</translation>
     </message>
     <message>
       <location filename="../gui/src/download-group-table-model.cpp" line="47"/>
       <source>Folder</source>
-      <translation type="unfinished"/>
+      <translation>文件夾</translation>
     </message>
     <message>
       <location filename="../gui/src/download-group-table-model.cpp" line="48"/>
       <source>Post-filtering</source>
-      <translation type="unfinished"/>
+      <translation>後過濾</translation>
     </message>
     <message>
       <location filename="../gui/src/download-group-table-model.cpp" line="49"/>
       <source>Get blacklisted</source>
-      <translation type="unfinished"/>
+      <translation>加入黑名單</translation>
     </message>
     <message>
       <location filename="../gui/src/download-group-table-model.cpp" line="50"/>
       <source>Galleries count as one</source>
-      <translation type="unfinished"/>
+      <translation>相冊計為一個</translation>
     </message>
     <message>
       <location filename="../gui/src/download-group-table-model.cpp" line="51"/>
       <source>Progress</source>
-      <translation type="unfinished"/>
+      <translation>進度</translation>
     </message>
     <message>
       <location filename="../gui/src/download-group-table-model.cpp" line="149"/>
       <source>This source is not valid.</source>
-      <translation type="unfinished"/>
+      <translation>此來源無效。</translation>
     </message>
     <message>
       <location filename="../gui/src/download-group-table-model.cpp" line="161"/>
       <source>The image per page value must be greater or equal to 1.</source>
-      <translation type="unfinished"/>
+      <translation>每頁圖片數必須大於等於 1。</translation>
     </message>
     <message>
       <location filename="../gui/src/download-group-table-model.cpp" line="171"/>
       <source>The image limit must be greater or equal to 0.</source>
-      <translation type="unfinished"/>
+      <translation>圖片數限制必須大於或等於 0。</translation>
     </message>
   </context>
   <context>
@@ -548,62 +550,62 @@
     <message>
       <location filename="../gui/src/download-image-table-model.cpp" line="35"/>
       <source>Id</source>
-      <translation type="unfinished"/>
+      <translation>Id</translation>
     </message>
     <message>
       <location filename="../gui/src/download-image-table-model.cpp" line="36"/>
       <source>Md5</source>
-      <translation type="unfinished"/>
+      <translation>Md5</translation>
     </message>
     <message>
       <location filename="../gui/src/download-image-table-model.cpp" line="37"/>
       <source>Rating</source>
-      <translation type="unfinished"/>
+      <translation>分級</translation>
     </message>
     <message>
       <location filename="../gui/src/download-image-table-model.cpp" line="38"/>
       <source>Tags</source>
-      <translation type="unfinished"/>
+      <translation>標籤</translation>
     </message>
     <message>
       <location filename="../gui/src/download-image-table-model.cpp" line="39"/>
       <source>Url</source>
-      <translation type="unfinished"/>
+      <translation>Url</translation>
     </message>
     <message>
       <location filename="../gui/src/download-image-table-model.cpp" line="40"/>
       <source>Date</source>
-      <translation type="unfinished"/>
+      <translation>日期</translation>
     </message>
     <message>
       <location filename="../gui/src/download-image-table-model.cpp" line="41"/>
       <source>Search</source>
-      <translation type="unfinished"/>
+      <translation>搜索</translation>
     </message>
     <message>
       <location filename="../gui/src/download-image-table-model.cpp" line="42"/>
       <source>Site</source>
-      <translation type="unfinished"/>
+      <translation>站點</translation>
     </message>
     <message>
       <location filename="../gui/src/download-image-table-model.cpp" line="43"/>
       <source>Filename</source>
-      <translation type="unfinished"/>
+      <translation>檔案名</translation>
     </message>
     <message>
       <location filename="../gui/src/download-image-table-model.cpp" line="44"/>
       <source>Folder</source>
-      <translation type="unfinished"/>
+      <translation>文件夾</translation>
     </message>
     <message>
       <location filename="../gui/src/download-image-table-model.cpp" line="45"/>
       <source>File size</source>
-      <translation type="unfinished"/>
+      <translation>檔案大小</translation>
     </message>
     <message>
       <location filename="../gui/src/download-image-table-model.cpp" line="46"/>
       <source>Dimensions</source>
-      <translation type="unfinished"/>
+      <translation>尺寸</translation>
     </message>
   </context>
   <context>
@@ -611,18 +613,18 @@
     <message>
       <location filename="../gui/src/tabs/downloads-tab.ui" line="26"/>
       <source>Downloads</source>
-      <translation type="unfinished"/>
+      <translation>下載</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.ui" line="54"/>
       <source>Groups (0/0)</source>
-      <translation type="unfinished"/>
+      <translation>分組 (0/0)</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.ui" line="61"/>
       <location filename="../gui/src/tabs/downloads-tab.ui" line="126"/>
       <source>Add</source>
-      <translation type="unfinished"/>
+      <translation>添加</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.ui" line="119"/>
@@ -632,48 +634,48 @@
     <message>
       <location filename="../gui/src/tabs/downloads-tab.ui" line="186"/>
       <source>Delete all</source>
-      <translation type="unfinished"/>
+      <translation>刪除所有</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.ui" line="193"/>
       <source>Delete selected</source>
-      <translation type="unfinished"/>
+      <translation>刪除已選擇的</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.ui" line="200"/>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="121"/>
       <source>Download</source>
-      <translation type="unfinished"/>
+      <translation>下載</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.ui" line="207"/>
       <source>Download selected</source>
-      <translation type="unfinished"/>
+      <translation>下載選中</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="126"/>
       <source>Move down</source>
-      <translation type="unfinished"/>
+      <translation>下移</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="125"/>
       <source>Move up</source>
-      <translation type="unfinished"/>
+      <translation>上移</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="177"/>
       <source>Confirmation</source>
-      <translation type="unfinished"/>
+      <translation>確認</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="177"/>
       <source>Are you sure you want to clear your download list?</source>
-      <translation type="unfinished"/>
+      <translation>確定清空下載列表？</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="124"/>
       <source>Move to top</source>
-      <translation type="unfinished"/>
+      <translation>移至頂端</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="122"/>
@@ -683,68 +685,70 @@
     <message>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="127"/>
       <source>Move to bottom</source>
-      <translation type="unfinished"/>
+      <translation>移至底部</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="130"/>
       <source>Remove</source>
-      <translation type="unfinished"/>
+      <translation>刪除</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="335"/>
       <source>Groups (%1/%2)</source>
-      <translation type="unfinished"/>
+      <translation>分組 (%1/%2)</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="367"/>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="376"/>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="378"/>
       <source>Save link list</source>
-      <translation type="unfinished"/>
+      <translation>保存連結列表</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="367"/>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="396"/>
       <source>Imageboard-Grabber links (*.igl)</source>
-      <translation type="unfinished"/>
+      <translation>Imageboard-Grabber 連結列表 (*.igl)</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="376"/>
       <source>Link list saved successfully!</source>
-      <translation type="unfinished"/>
+      <translation>連結列表保存成功！</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="378"/>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="409"/>
       <source>Error opening file.</source>
-      <translation type="unfinished"/>
+      <translation>打開文件時發生錯誤。</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="396"/>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="407"/>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="409"/>
       <source>Load link list</source>
-      <translation type="unfinished"/>
+      <translation>載入連結列表</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="407"/>
       <source>Link list loaded successfully!</source>
-      <translation type="unfinished"/>
+      <translation>連結列表導入完成！</translation>
     </message>
     <message numerus="yes">
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="421"/>
       <source>Loading %n download(s)</source>
-      <translation type="unfinished"/>
+      <translation>
+        <numerusform>正在載入 %n 個下載</numerusform>
+      </translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="473"/>
       <source>You did not specify a save folder!</source>
-      <translation type="unfinished"/>
+      <translation>你還沒有指定保存文件夾！</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="477"/>
       <source>You did not specify a filename!</source>
-      <translation type="unfinished"/>
+      <translation>你還沒有指定檔案名！</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="565"/>
@@ -754,96 +758,113 @@
     <message>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="585"/>
       <source>You are going to download up to %1 images, which can take a long time and space on your computer. Are you sure you want to proceed?</source>
-      <translation type="unfinished"/>
+      <translation>你將要下載 %1 張圖片，可能花費很長時間並占用大量空間。你確定要繼續嗎？</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="587"/>
       <source>Don't ask me again</source>
-      <translation type="unfinished"/>
+      <translation>不再詢問</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="624"/>
       <source>Logging in, please wait...</source>
-      <translation type="unfinished"/>
+      <translation>登錄中，請稍候...</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="709"/>
       <source>Downloading pages, please wait...</source>
-      <translation type="unfinished"/>
+      <translation>下載頁面中，請稍候...</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="783"/>
       <source>Preparing images, please wait...</source>
-      <translation type="unfinished"/>
+      <translation>準備圖片中，請稍候...</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="797"/>
       <source>Downloading images...</source>
-      <translation type="unfinished"/>
+      <translation>下載圖片中...</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="993"/>
       <source>Not enough space on the destination drive "%1".
 Please free some space before resuming the download.</source>
-      <translation type="unfinished"/>
+      <translation>目標驅動器 "%1" 容量不足。
+請清理出可用空間後繼續下載。</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="995"/>
       <source>An error occured saving the image.
 %1
 Please solve the issue before resuming the download.</source>
-      <translation type="unfinished"/>
+      <translation>保存圖片時出現錯誤。
+%1
+請在恢復下載前修復這些問題。</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="997"/>
       <source>Error</source>
-      <translation type="unfinished"/>
+      <translation>錯誤</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="1092"/>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="1121"/>
       <source>Getting images</source>
-      <translation type="unfinished"/>
+      <translation>獲取圖片</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="1092"/>
       <source>Errors occured during the images download. Do you want to restart the download of those images? (%1/%2)</source>
-      <translation type="unfinished"/>
+      <translation>下載圖片時出現錯誤。請問你想要重啟這些圖片的下載嗎？(%1/%2)</translation>
     </message>
     <message numerus="yes">
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="1123"/>
       <source>%n file(s) downloaded successfully.</source>
-      <translation type="unfinished"/>
+      <translation>
+        <numerusform>%n 個圖片已成功下載。</numerusform>
+      </translation>
     </message>
     <message numerus="yes">
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="1124"/>
       <source>%n file(s) ignored.</source>
-      <translation type="unfinished"/>
+      <translation>
+        <numerusform>%n 個文件被忽略。</numerusform>
+      </translation>
     </message>
     <message numerus="yes">
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="1125"/>
       <source>%n file(s) already existing.</source>
-      <translation type="unfinished"/>
+      <translation>
+        <numerusform>%n 個文件已經存在。</numerusform>
+      </translation>
     </message>
     <message numerus="yes">
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="1126"/>
       <source>%n file(s) not found on the server.</source>
-      <translation type="unfinished"/>
+      <translation>
+        <numerusform>%n 個文件在伺服器上無法找到。</numerusform>
+      </translation>
     </message>
     <message numerus="yes">
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="1127"/>
       <source>%n file(s) skipped.</source>
-      <translation type="unfinished"/>
+      <translation>
+        <numerusform>%n 個文件被跳過。</numerusform>
+      </translation>
     </message>
     <message numerus="yes">
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="1128"/>
       <source>%n file(s) skipped from a previous download.</source>
-      <translation type="unfinished"/>
+      <translation>
+        <numerusform>%n 個之前下載過的文件被跳過。</numerusform>
+      </translation>
     </message>
     <message numerus="yes">
       <location filename="../gui/src/tabs/downloads-tab.cpp" line="1129"/>
       <source>%n error(s).</source>
-      <translation type="unfinished"/>
+      <translation>
+        <numerusform>%n 個錯誤。</numerusform>
+      </translation>
     </message>
   </context>
   <context>
@@ -852,27 +873,27 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/utils/empty-dirs-fix/empty-dirs-fix-1.ui" line="14"/>
       <location filename="../gui/src/utils/empty-dirs-fix/empty-dirs-fix-1.cpp" line="33"/>
       <source>Empty folders fixer</source>
-      <translation type="unfinished"/>
+      <translation>空文件夾修復</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/empty-dirs-fix/empty-dirs-fix-1.ui" line="24"/>
       <source>Folder</source>
-      <translation type="unfinished"/>
+      <translation>文件夾</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/empty-dirs-fix/empty-dirs-fix-1.ui" line="49"/>
       <source>Continue</source>
-      <translation type="unfinished"/>
+      <translation>繼續</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/empty-dirs-fix/empty-dirs-fix-1.ui" line="56"/>
       <source>Cancel</source>
-      <translation type="unfinished"/>
+      <translation>取消</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/empty-dirs-fix/empty-dirs-fix-1.cpp" line="33"/>
       <source>No empty folder found.</source>
-      <translation type="unfinished"/>
+      <translation>找不到空文件夾</translation>
     </message>
   </context>
   <context>
@@ -882,32 +903,34 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/utils/empty-dirs-fix/empty-dirs-fix-2.cpp" line="44"/>
       <location filename="../gui/src/utils/empty-dirs-fix/empty-dirs-fix-2.cpp" line="48"/>
       <source>Empty folders fixer</source>
-      <translation type="unfinished"/>
+      <translation>空文件夾修復</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/empty-dirs-fix/empty-dirs-fix-2.ui" line="24"/>
       <source>Choose folders to delete in the list below.</source>
-      <translation type="unfinished"/>
+      <translation>在下面的列表中選擇需要刪除的文件夾</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/empty-dirs-fix/empty-dirs-fix-2.ui" line="53"/>
       <source>Delete</source>
-      <translation type="unfinished"/>
+      <translation>刪除</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/empty-dirs-fix/empty-dirs-fix-2.ui" line="60"/>
       <source>Cancel</source>
-      <translation type="unfinished"/>
+      <translation>取消</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/empty-dirs-fix/empty-dirs-fix-2.cpp" line="44"/>
       <source>No folder selected.</source>
-      <translation type="unfinished"/>
+      <translation>未選中文件夾</translation>
     </message>
     <message numerus="yes">
       <location filename="../gui/src/utils/empty-dirs-fix/empty-dirs-fix-2.cpp" line="48"/>
       <source>You are about to delete %n folder. Are you sure you want to continue?</source>
-      <translation type="unfinished"/>
+      <translation>
+        <numerusform>你將刪除 %n 個文件夾。你確定要繼續嗎？</numerusform>
+      </translation>
     </message>
   </context>
   <context>
@@ -915,142 +938,142 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/favorite-window.ui" line="14"/>
       <source>Edit a favorite</source>
-      <translation type="unfinished"/>
+      <translation>修改收藏</translation>
     </message>
     <message>
       <location filename="../gui/src/favorite-window.ui" line="28"/>
       <source>General</source>
-      <translation type="unfinished"/>
+      <translation>一般</translation>
     </message>
     <message>
       <location filename="../gui/src/favorite-window.ui" line="34"/>
       <source>Tag corresponding to the favorite. It is not often useful to change it.</source>
-      <translation type="unfinished"/>
+      <translation>標籤和收藏相對應。大部分時候不需要修改。</translation>
     </message>
     <message>
       <location filename="../gui/src/favorite-window.ui" line="37"/>
       <source>Tag</source>
-      <translation type="unfinished"/>
+      <translation>標籤</translation>
     </message>
     <message>
       <location filename="../gui/src/favorite-window.ui" line="47"/>
       <source>Between 0 and 100, the note can be used to sort the favorites in preference order.</source>
-      <translation type="unfinished"/>
+      <translation>值在 0 到 100 之間，備註可以用於按喜好排序收藏。</translation>
     </message>
     <message>
       <location filename="../gui/src/favorite-window.ui" line="57"/>
       <source> %</source>
-      <translation type="unfinished"/>
+      <translation> %</translation>
     </message>
     <message>
       <location filename="../gui/src/favorite-window.ui" line="70"/>
       <source>Last time you clicked on "Mark as viewed".</source>
-      <translation type="unfinished"/>
+      <translation>上一次你選擇”標記為看過“。</translation>
     </message>
     <message>
       <location filename="../gui/src/favorite-window.ui" line="73"/>
       <source>Last view</source>
-      <translation type="unfinished"/>
+      <translation>上次查看</translation>
     </message>
     <message>
       <location filename="../gui/src/favorite-window.ui" line="80"/>
       <source>yyyy/MM/dd HH:mm:ss</source>
-      <translation type="unfinished"/>
+      <translation>yyyy/MM/dd HH:mm:ss</translation>
     </message>
     <message>
       <location filename="../gui/src/favorite-window.ui" line="87"/>
       <source>Image whose icon will be displayed in the favorites list.</source>
-      <translation type="unfinished"/>
+      <translation>在收藏列表顯示的圖示。</translation>
     </message>
     <message>
       <location filename="../gui/src/favorite-window.ui" line="90"/>
       <source>Image</source>
-      <translation type="unfinished"/>
+      <translation>圖片</translation>
     </message>
     <message>
       <location filename="../gui/src/favorite-window.ui" line="112"/>
       <source>Browse</source>
-      <translation type="unfinished"/>
+      <translation>瀏覽</translation>
     </message>
     <message>
       <location filename="../gui/src/favorite-window.ui" line="121"/>
       <source>Post-filtering</source>
-      <translation type="unfinished"/>
+      <translation>後過濾</translation>
     </message>
     <message>
       <location filename="../gui/src/favorite-window.ui" line="131"/>
       <source>Sources</source>
-      <translation type="unfinished"/>
+      <translation>來源</translation>
     </message>
     <message>
       <location filename="../gui/src/favorite-window.ui" line="138"/>
       <source>Edit sources</source>
-      <translation type="unfinished"/>
+      <translation>編輯來源</translation>
     </message>
     <message>
       <location filename="../gui/src/favorite-window.ui" line="146"/>
       <source>Monitors</source>
-      <translation type="unfinished"/>
+      <translation>監視</translation>
     </message>
     <message>
       <location filename="../gui/src/favorite-window.ui" line="162"/>
       <source>Monitoring interval</source>
-      <translation type="unfinished"/>
+      <translation>監視間隔</translation>
     </message>
     <message>
       <location filename="../gui/src/favorite-window.ui" line="169"/>
       <source> min</source>
-      <translation type="unfinished"/>
+      <translation> 分鐘</translation>
     </message>
     <message>
       <location filename="../gui/src/favorite-window.ui" line="184"/>
       <source>Set the interval to 0 to disable monitoring.</source>
-      <translation type="unfinished"/>
+      <translation>設置間隔為 0 禁用監視</translation>
     </message>
     <message>
       <location filename="../gui/src/favorite-window.ui" line="152"/>
       <source>Source</source>
-      <translation type="unfinished"/>
+      <translation>來源</translation>
     </message>
     <message>
       <location filename="../gui/src/favorite-window.ui" line="50"/>
       <source>Priority</source>
-      <translation type="unfinished"/>
+      <translation>優先度</translation>
     </message>
     <message>
       <location filename="../gui/src/favorite-window.ui" line="194"/>
       <source>Download</source>
-      <translation type="unfinished"/>
+      <translation>下載</translation>
     </message>
     <message>
       <location filename="../gui/src/favorite-window.ui" line="201"/>
       <source>Path</source>
-      <translation type="unfinished"/>
+      <translation>路徑</translation>
     </message>
     <message>
       <location filename="../gui/src/favorite-window.ui" line="208"/>
       <source>Filename</source>
-      <translation type="unfinished"/>
+      <translation>檔案名</translation>
     </message>
     <message>
       <location filename="../gui/src/favorite-window.ui" line="220"/>
       <source>Leave empty to use default settings.</source>
-      <translation type="unfinished"/>
+      <translation>留空將使用默認設置</translation>
     </message>
     <message>
       <location filename="../gui/src/favorite-window.ui" line="256"/>
       <source>Delete</source>
-      <translation type="unfinished"/>
+      <translation>刪除</translation>
     </message>
     <message>
       <location filename="../gui/src/favorite-window.cpp" line="69"/>
       <source>Choose an image</source>
-      <translation type="unfinished"/>
+      <translation>選擇一張圖片</translation>
     </message>
     <message>
       <location filename="../gui/src/favorite-window.cpp" line="77"/>
       <source>Choose a save folder</source>
-      <translation type="unfinished"/>
+      <translation>選擇保存文件夾</translation>
     </message>
   </context>
   <context>
@@ -1058,27 +1081,27 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/docks/favorites-dock.ui" line="26"/>
       <source>Downloads</source>
-      <translation type="unfinished"/>
+      <translation>下載</translation>
     </message>
     <message>
       <location filename="../gui/src/docks/favorites-dock.ui" line="39"/>
       <source>Name</source>
-      <translation type="unfinished"/>
+      <translation>名稱</translation>
     </message>
     <message>
       <location filename="../gui/src/docks/favorites-dock.ui" line="44"/>
       <source>Priority</source>
-      <translation type="unfinished"/>
+      <translation>優先度</translation>
     </message>
     <message>
       <location filename="../gui/src/docks/favorites-dock.ui" line="49"/>
       <source>Last viewed</source>
-      <translation type="unfinished"/>
+      <translation>上次查看</translation>
     </message>
     <message>
       <location filename="../gui/src/docks/favorites-dock.cpp" line="106"/>
       <source>&lt;b&gt;Name:&lt;/b&gt; %1&lt;br/&gt;&lt;b&gt;Note:&lt;/b&gt; %2 %%&lt;br/&gt;&lt;b&gt;Last view:&lt;/b&gt; %3</source>
-      <translation type="unfinished"/>
+      <translation>&lt;b&gt;名稱: &lt;/b&gt; %1&lt;br/&gt;&lt;b&gt;注釋: &lt;/b&gt; %2 %%&lt;br/&gt;&lt;b&gt;上次查看: &lt;/b&gt; %3</translation>
     </message>
   </context>
   <context>
@@ -1088,133 +1111,133 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/tabs/favorites-tab.cpp" line="463"/>
       <location filename="../gui/src/tabs/favorites-tab.cpp" line="469"/>
       <source>Favorites</source>
-      <translation type="unfinished"/>
+      <translation>收藏</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/favorites-tab.ui" line="63"/>
       <source>Sort by</source>
-      <translation type="unfinished"/>
+      <translation>篩選</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/favorites-tab.ui" line="80"/>
       <source>Name</source>
-      <translation type="unfinished"/>
+      <translation>名稱</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/favorites-tab.ui" line="85"/>
       <source>Priority</source>
-      <translation type="unfinished"/>
+      <translation>優先度</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/favorites-tab.ui" line="90"/>
       <source>Last view</source>
-      <translation type="unfinished"/>
+      <translation>上次查看</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/favorites-tab.ui" line="102"/>
       <source>Ascending</source>
-      <translation type="unfinished"/>
+      <translation>升序</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/favorites-tab.ui" line="107"/>
       <source>Descending</source>
-      <translation type="unfinished"/>
+      <translation>降序</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/favorites-tab.ui" line="224"/>
       <source>O&amp;k</source>
-      <translation type="unfinished"/>
+      <translation>確定 (&amp;K)</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/favorites-tab.ui" line="271"/>
       <source>Number of columns</source>
-      <translation type="unfinished"/>
+      <translation>列數</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/favorites-tab.ui" line="278"/>
       <source>Post-filtering</source>
-      <translation type="unfinished"/>
+      <translation>後過濾</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/favorites-tab.ui" line="298"/>
       <source>Images per page</source>
-      <translation type="unfinished"/>
+      <translation>每頁圖片數</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/favorites-tab.ui" line="534"/>
       <source>Back</source>
-      <translation type="unfinished"/>
+      <translation>返回</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/favorites-tab.ui" line="544"/>
       <source>Mark as &amp;viewed</source>
-      <translation type="unfinished"/>
+      <translation>標記為看過 (&amp;V)</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/favorites-tab.ui" line="551"/>
       <source>Get &amp;selected</source>
-      <translation type="unfinished"/>
+      <translation>獲取選中 (&amp;S)</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/favorites-tab.ui" line="558"/>
       <source>Get this &amp;page</source>
-      <translation type="unfinished"/>
+      <translation>獲取此頁 (&amp;P)</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/favorites-tab.ui" line="565"/>
       <source>Get &amp;all</source>
-      <translation type="unfinished"/>
+      <translation>獲取全部 (&amp;A)</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/favorites-tab.ui" line="612"/>
       <source>S&amp;ources</source>
-      <translation type="unfinished"/>
+      <translation>來源 (&amp;O)</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/favorites-tab.ui" line="619"/>
       <source>Merge results</source>
-      <translation type="unfinished"/>
+      <translation>合併結果</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/favorites-tab.ui" line="669"/>
       <source>Mark all as vie&amp;wed</source>
-      <translation type="unfinished"/>
+      <translation>標記所有為看過 (&amp;W)</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/favorites-tab.cpp" line="136"/>
       <source>You don't have any favorite yet.</source>
-      <translation type="unfinished"/>
+      <translation>你還沒有任何收藏</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/favorites-tab.cpp" line="149"/>
       <source>&lt;b&gt;Name:&lt;/b&gt; %1&lt;br/&gt;&lt;b&gt;Note:&lt;/b&gt; %2 %&lt;br/&gt;&lt;b&gt;Last view:&lt;/b&gt; %3</source>
-      <translation type="unfinished"/>
+      <translation>&lt;b&gt;名稱: &lt;/b&gt; %1&lt;br/&gt;&lt;b&gt;注釋: &lt;/b&gt; %2 %&lt;br/&gt;&lt;b&gt;上次查看: &lt;/b&gt; %3</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/favorites-tab.cpp" line="244"/>
       <location filename="../gui/src/tabs/favorites-tab.cpp" line="252"/>
       <source>No result since the %1</source>
-      <translation type="unfinished"/>
+      <translation>從 %1 開始沒有結果</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/favorites-tab.cpp" line="441"/>
       <source>Mark as last viewed</source>
-      <translation type="unfinished"/>
+      <translation>標記為已看</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/favorites-tab.cpp" line="448"/>
       <source>Choose as image</source>
-      <translation type="unfinished"/>
+      <translation>選擇一個圖片</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/favorites-tab.cpp" line="349"/>
       <source>Mark as viewed</source>
-      <translation type="unfinished"/>
+      <translation>標記為看過</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/favorites-tab.cpp" line="349"/>
       <source>Are you sure you want to mark all your favorites as viewed?</source>
-      <translation type="unfinished"/>
+      <translation>你確定要標記所有收藏為已看嗎？</translation>
     </message>
   </context>
   <context>
@@ -1222,27 +1245,27 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/settings/filename-window.ui" line="14"/>
       <source>Filenaming</source>
-      <translation type="unfinished"/>
+      <translation>命名文件</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/filename-window.ui" line="22"/>
       <source>Classic filenaming</source>
-      <translation type="unfinished"/>
+      <translation>經典命名方式</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/filename-window.ui" line="68"/>
       <source>Javascript filenaming</source>
-      <translation type="unfinished"/>
+      <translation>Javascript 命名方式</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/filename-window.cpp" line="142"/>
       <source>Warning</source>
-      <translation type="unfinished"/>
+      <translation>警告</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/filename-window.cpp" line="142"/>
       <source>You script contains error, are you sure you want to save it?</source>
-      <translation type="unfinished"/>
+      <translation>你的腳本包含錯誤，你確定要保存嗎？</translation>
     </message>
   </context>
   <context>
@@ -1250,42 +1273,42 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/tabs/gallery-tab.ui" line="129"/>
       <source>O&amp;k</source>
-      <translation type="unfinished"/>
+      <translation>確定 (&amp;K)</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/gallery-tab.ui" line="176"/>
       <source>Post-filtering</source>
-      <translation type="unfinished"/>
+      <translation>後過濾</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/gallery-tab.ui" line="183"/>
       <source>Number of columns</source>
-      <translation type="unfinished"/>
+      <translation>列數</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/gallery-tab.ui" line="190"/>
       <source>Images per page</source>
-      <translation type="unfinished"/>
+      <translation>每頁圖片數</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/gallery-tab.ui" line="318"/>
       <source>Monitor</source>
-      <translation type="unfinished"/>
+      <translation>監視</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/gallery-tab.ui" line="325"/>
       <source>Get &amp;selected</source>
-      <translation type="unfinished"/>
+      <translation>獲取選中 (&amp;S)</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/gallery-tab.ui" line="332"/>
       <source>Get this &amp;page</source>
-      <translation type="unfinished"/>
+      <translation>獲取此頁 (&amp;P)</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/gallery-tab.ui" line="339"/>
       <source>Get &amp;all</source>
-      <translation type="unfinished"/>
+      <translation>獲取全部 (&amp;A)</translation>
     </message>
   </context>
   <context>
@@ -1293,157 +1316,159 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1081"/>
       <source>&lt;b&gt;Tags:&lt;/b&gt; %1&lt;br/&gt;&lt;br/&gt;</source>
-      <translation type="unfinished"/>
+      <translation>&lt;b&gt;標籤:&lt;/b&gt; %1&lt;br/&gt;&lt;br/&gt;</translation>
     </message>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1082"/>
       <source>&lt;b&gt;ID:&lt;/b&gt; %1&lt;br/&gt;</source>
-      <translation type="unfinished"/>
+      <translation>&lt;b&gt;ID:&lt;/b&gt; %1&lt;br/&gt;</translation>
     </message>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1083"/>
       <source>&lt;b&gt;Name:&lt;/b&gt; %1&lt;br/&gt;</source>
-      <translation type="unfinished"/>
+      <translation>&lt;b&gt;名稱:&lt;/b&gt; %1&lt;br/&gt;</translation>
     </message>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1084"/>
       <source>&lt;b&gt;Rating:&lt;/b&gt; %1&lt;br/&gt;</source>
-      <translation type="unfinished"/>
+      <translation>&lt;b&gt;分級:&lt;/b&gt; %1&lt;br/&gt;</translation>
     </message>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1085"/>
       <source>&lt;b&gt;Score:&lt;/b&gt; %1&lt;br/&gt;</source>
-      <translation type="unfinished"/>
+      <translation>&lt;b&gt;得分:&lt;/b&gt; %1&lt;br/&gt;</translation>
     </message>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1086"/>
       <source>&lt;b&gt;User:&lt;/b&gt; %1&lt;br/&gt;&lt;br/&gt;</source>
-      <translation type="unfinished"/>
+      <translation>&lt;b&gt;用戶:&lt;/b&gt; %1&lt;br/&gt;&lt;br/&gt;</translation>
     </message>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1087"/>
       <source>&lt;b&gt;Size:&lt;/b&gt; %1 x %2&lt;br/&gt;</source>
-      <translation type="unfinished"/>
+      <translation>&lt;b&gt;大小:&lt;/b&gt; %1 x %2&lt;br/&gt;</translation>
     </message>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1088"/>
       <source>&lt;b&gt;Filesize:&lt;/b&gt; %1 %2&lt;br/&gt;</source>
-      <translation type="unfinished"/>
+      <translation>&lt;b&gt;檔案大小:&lt;/b&gt; %1 %2&lt;br/&gt;</translation>
     </message>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1089"/>
       <source>&lt;b&gt;Date:&lt;/b&gt; %1</source>
-      <translation type="unfinished"/>
+      <translation>&lt;b&gt;日期:&lt;/b&gt; %1</translation>
     </message>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1099"/>
       <source>&lt;i&gt;Unknown&lt;/i&gt;</source>
-      <translation type="unfinished"/>
+      <translation>&lt;i&gt;未知&lt;/i&gt;</translation>
     </message>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1100"/>
       <source>yes</source>
-      <translation type="unfinished"/>
+      <translation>是</translation>
     </message>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1101"/>
       <source>no</source>
-      <translation type="unfinished"/>
+      <translation>否</translation>
     </message>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1114"/>
       <source>Tags</source>
-      <translation type="unfinished"/>
+      <translation>標籤</translation>
     </message>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1116"/>
       <source>ID</source>
-      <translation type="unfinished"/>
+      <translation>ID</translation>
     </message>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1117"/>
       <source>MD5</source>
-      <translation type="unfinished"/>
+      <translation>MD5</translation>
     </message>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1118"/>
       <source>Rating</source>
-      <translation type="unfinished"/>
+      <translation>分級</translation>
     </message>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1119"/>
       <source>Score</source>
-      <translation type="unfinished"/>
+      <translation>得分</translation>
     </message>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1120"/>
       <source>Author</source>
-      <translation type="unfinished"/>
+      <translation>作者</translation>
     </message>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1122"/>
       <source>Date</source>
-      <translation type="unfinished"/>
+      <translation>日期</translation>
     </message>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1123"/>
       <source>Size</source>
-      <translation type="unfinished"/>
+      <translation>大小</translation>
     </message>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1124"/>
       <source>Filesize</source>
-      <translation type="unfinished"/>
+      <translation>檔案大小</translation>
     </message>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1126"/>
       <source>Page</source>
-      <translation type="unfinished"/>
+      <translation>頁面</translation>
     </message>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1127"/>
       <source>URL</source>
-      <translation type="unfinished"/>
+      <translation>URL</translation>
     </message>
     <message numerus="yes">
       <location filename="../lib/src/models/image.cpp" line="1128"/>
       <source>Source(s)</source>
-      <translation type="unfinished"/>
+      <translation>
+        <numerusform>來源</numerusform>
+      </translation>
     </message>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1129"/>
       <source>Sample</source>
-      <translation type="unfinished"/>
+      <translation>樣本</translation>
     </message>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1130"/>
       <source>Thumbnail</source>
-      <translation type="unfinished"/>
+      <translation>縮圖</translation>
     </message>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1132"/>
       <source>Parent</source>
-      <translation type="unfinished"/>
+      <translation>父級</translation>
     </message>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1132"/>
       <source>yes (#%1)</source>
-      <translation type="unfinished"/>
+      <translation>是 (#%1)</translation>
     </message>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1133"/>
       <source>Comments</source>
-      <translation type="unfinished"/>
+      <translation>評論</translation>
     </message>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1134"/>
       <source>Children</source>
-      <translation type="unfinished"/>
+      <translation>子級</translation>
     </message>
     <message>
       <location filename="../lib/src/models/image.cpp" line="1135"/>
       <source>Notes</source>
-      <translation type="unfinished"/>
+      <translation>備註</translation>
     </message>
   </context>
   <context>
@@ -1461,17 +1486,17 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/image-context-menu.cpp" line="26"/>
       <source>Open in browser</source>
-      <translation type="unfinished"/>
+      <translation>在瀏覽器中打開</translation>
     </message>
     <message>
       <location filename="../gui/src/image-context-menu.cpp" line="29"/>
       <source>Web services</source>
-      <translation type="unfinished"/>
+      <translation>在線服務</translation>
     </message>
     <message>
       <location filename="../gui/src/image-context-menu.cpp" line="40"/>
       <source>Search MD5</source>
-      <translation type="unfinished"/>
+      <translation>MD5 搜索</translation>
     </message>
   </context>
   <context>
@@ -1479,22 +1504,22 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/tabs/image-preview.cpp" line="264"/>
       <source>Delete</source>
-      <translation type="unfinished"/>
+      <translation>刪除</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/image-preview.cpp" line="266"/>
       <source>Save</source>
-      <translation type="unfinished"/>
+      <translation>保存</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/image-preview.cpp" line="272"/>
       <source>Save as...</source>
-      <translation type="unfinished"/>
+      <translation>保存為...</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/image-preview.cpp" line="336"/>
       <source>Save image</source>
-      <translation type="unfinished"/>
+      <translation>保存圖片</translation>
     </message>
   </context>
   <context>
@@ -1502,7 +1527,7 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/docks/keep-for-later-dock.ui" line="26"/>
       <source>Downloads</source>
-      <translation type="unfinished"/>
+      <translation>下載</translation>
     </message>
   </context>
   <context>
@@ -1510,7 +1535,7 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../lib/src/language-loader.cpp" line="93"/>
       <source>en_US</source>
-      <translation type="unfinished"/>
+      <translation>zh_TW</translation>
     </message>
   </context>
   <context>
@@ -1518,7 +1543,7 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/tabs/log-tab.ui" line="26"/>
       <source>Log</source>
-      <translation type="unfinished"/>
+      <translation>日誌</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/log-tab.ui" line="71"/>
@@ -1541,63 +1566,63 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/settings/log-window.ui" line="14"/>
       <source>Log</source>
-      <translation type="unfinished"/>
+      <translation>日誌</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/log-window.ui" line="20"/>
       <source>Location type</source>
-      <translation type="unfinished"/>
+      <translation>位置類型</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/log-window.ui" line="28"/>
       <source>Path and filename</source>
-      <translation type="unfinished"/>
+      <translation>路徑和檔案名</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/log-window.ui" line="33"/>
       <source>Unique file</source>
-      <translation type="unfinished"/>
+      <translation>唯一文件</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/log-window.ui" line="38"/>
       <location filename="../gui/src/settings/log-window.ui" line="169"/>
       <source>Suffix</source>
-      <translation type="unfinished"/>
+      <translation>後綴</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/log-window.ui" line="62"/>
       <source>Folder</source>
-      <translation type="unfinished"/>
+      <translation>文件夾</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/log-window.ui" line="89"/>
       <source>Filename</source>
-      <translation type="unfinished"/>
+      <translation>檔案名</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/log-window.ui" line="129"/>
       <source>Path</source>
-      <translation type="unfinished"/>
+      <translation>路徑</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/log-window.ui" line="184"/>
       <source>Each time an image is saved, an external text file will be saved with the same name at the same location.</source>
-      <translation type="unfinished"/>
+      <translation>每當圖片保存時，一個文本文件將儲存在相同的地方，包含這個圖片的標籤。</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/log-window.ui" line="198"/>
       <source>Text file content</source>
-      <translation type="unfinished"/>
+      <translation>文本文件內容</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/log-window.ui" line="223"/>
       <source>Available tokens: the same as in the "Save" part.</source>
-      <translation type="unfinished"/>
+      <translation>有效的變數：和”保存“節的內容相同。</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/log-window.ui" line="233"/>
       <source>Name</source>
-      <translation type="unfinished"/>
+      <translation>名稱</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/log-window.cpp" line="39"/>
@@ -1612,176 +1637,176 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/main-window.ui" line="136"/>
       <location filename="../gui/src/main-window.ui" line="341"/>
       <source>Tags</source>
-      <translation type="unfinished"/>
+      <translation>標籤</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="75"/>
       <source>Help</source>
-      <translation type="unfinished"/>
+      <translation>幫助</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="89"/>
       <source>Tools</source>
-      <translation type="unfinished"/>
+      <translation>工具</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="102"/>
       <source>View</source>
-      <translation type="unfinished"/>
+      <translation>查看</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="107"/>
       <source>File</source>
-      <translation type="unfinished"/>
+      <translation>文件</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="124"/>
       <source>Edit</source>
-      <translation type="unfinished"/>
+      <translation>編輯</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="160"/>
       <location filename="../gui/src/main-window.ui" line="352"/>
       <location filename="../gui/src/main-window.ui" line="355"/>
       <source>Kept for later</source>
-      <translation type="unfinished"/>
+      <translation>稍後再看</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="184"/>
       <location filename="../gui/src/main-window.ui" line="366"/>
       <source>Favorites</source>
-      <translation type="unfinished"/>
+      <translation>收藏</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="208"/>
       <source>Wiki</source>
-      <translation type="unfinished"/>
+      <translation>百科</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="232"/>
       <source>Destination</source>
-      <translation type="unfinished"/>
+      <translation>保存目的地</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="263"/>
       <source>Options</source>
-      <translation type="unfinished"/>
+      <translation>選項</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="266"/>
       <source>Ctrl+P</source>
-      <translation type="unfinished"/>
+      <translation>Ctrl+P</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="275"/>
       <source>Open destination folder</source>
-      <translation type="unfinished"/>
+      <translation>打開目標文件夾</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="284"/>
       <source>Quit</source>
-      <translation type="unfinished"/>
+      <translation>退出</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="293"/>
       <source>About Grabber</source>
-      <translation type="unfinished"/>
+      <translation>關於 Grabber</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="302"/>
       <source>About Qt</source>
-      <translation type="unfinished"/>
+      <translation>關於 Qt</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="311"/>
       <location filename="../gui/src/main-window.cpp" line="535"/>
       <source>New tab</source>
-      <translation type="unfinished"/>
+      <translation>新標籤頁</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="320"/>
       <source>Close tab</source>
-      <translation type="unfinished"/>
+      <translation>關閉標籤頁</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="325"/>
       <source>Blacklist fixer</source>
-      <translation type="unfinished"/>
+      <translation>黑名單修復</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="330"/>
       <source>Empty folders fixer</source>
-      <translation type="unfinished"/>
+      <translation>空文件夾修復</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="375"/>
       <source>New pool tab</source>
-      <translation type="unfinished"/>
+      <translation>新集合標籤頁</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="380"/>
       <source>MD5 list fixer</source>
-      <translation type="unfinished"/>
+      <translation>MD5 列表修復</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="389"/>
       <source>Open options folder</source>
-      <translation type="unfinished"/>
+      <translation>打開選項文件夾</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="398"/>
       <source>Project website</source>
-      <translation type="unfinished"/>
+      <translation>項目網站</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="407"/>
       <source>Report an issue</source>
-      <translation type="unfinished"/>
+      <translation>報告問題</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="412"/>
       <source>Rename existing images</source>
-      <translation type="unfinished"/>
+      <translation>重命名已有圖片</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="421"/>
       <source>Project GitHub</source>
-      <translation type="unfinished"/>
+      <translation>項目 GitHub</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="433"/>
       <source>Restore last closed tab</source>
-      <translation type="unfinished"/>
+      <translation>恢復最近關閉的標籤頁</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="441"/>
       <source>Tag loader</source>
-      <translation type="unfinished"/>
+      <translation>標籤載入器</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="450"/>
       <source>Save downloads list</source>
-      <translation type="unfinished"/>
+      <translation>保存下載列表</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="459"/>
       <source>Load downloads list</source>
-      <translation type="unfinished"/>
+      <translation>載入下載列表</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="464"/>
       <source>MD5 database converter</source>
-      <translation type="unfinished"/>
+      <translation>MD5 資料庫轉換</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="473"/>
       <source>Donate with PayPal</source>
-      <translation type="unfinished"/>
+      <translation>通過 PayPal 捐贈</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="482"/>
       <source>Donate with Patreon</source>
-      <translation type="unfinished"/>
+      <translation>通過 Patreon 捐贈</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.ui" line="487"/>
@@ -1791,52 +1816,52 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/main-window.cpp" line="161"/>
       <source>No source found</source>
-      <translation type="unfinished"/>
+      <translation>找不到來源</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.cpp" line="161"/>
       <source>No source found. Do you have a configuration problem? Try to reinstall the program.</source>
-      <translation type="unfinished"/>
+      <translation>找不到來源。配置是否有問題？請嘗試重新安裝程式。</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.cpp" line="176"/>
       <source>&amp;Quit</source>
-      <translation type="unfinished"/>
+      <translation>退出 (&amp;Q)</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.cpp" line="255"/>
       <source>It seems that the application was not properly closed for its last use. Do you want to restore your last session?</source>
-      <translation type="unfinished"/>
+      <translation>看來上次程序沒有正常退出。你想要恢復上次的會話嗎？</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.cpp" line="281"/>
       <source>Grabber monitoring</source>
-      <translation type="unfinished"/>
+      <translation>Grabber 監視器</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.cpp" line="474"/>
       <source>The Mozilla Firefox addon "Danbooru Downloader" has been detected on your system. Do you want to load its preferences?</source>
-      <translation type="unfinished"/>
+      <translation>檢測到你有安裝 Firefox 插件 "Danbooru Downloader"。你想要導入它的設置嗎？</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.cpp" line="772"/>
       <source>Don't ask me again</source>
-      <translation type="unfinished"/>
+      <translation>不再詢問</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.cpp" line="926"/>
       <source>Unlock tab</source>
-      <translation type="unfinished"/>
+      <translation>解鎖標籤頁</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.cpp" line="931"/>
       <source>Lock tab</source>
-      <translation type="unfinished"/>
+      <translation>鎖定標籤頁</translation>
     </message>
     <message>
       <location filename="../gui/src/main-window.cpp" line="770"/>
       <source>Are you sure you want to quit?</source>
-      <translation type="unfinished"/>
+      <translation>你確定要退出嗎？</translation>
     </message>
   </context>
   <context>
@@ -1844,37 +1869,39 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/utils/md5-database-converter/md5-database-converter.ui" line="14"/>
       <source>MD5 database converter</source>
-      <translation type="unfinished"/>
+      <translation>MD5 資料庫轉換</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/md5-database-converter/md5-database-converter.ui" line="30"/>
       <source>Generate a SQLite MD5 database using an existing TXT MD5 database.</source>
-      <translation type="unfinished"/>
+      <translation>使用現有的 TXT MD5 資料庫生成 SQLite MD5 資料庫。</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/md5-database-converter/md5-database-converter.ui" line="78"/>
       <source>Start</source>
-      <translation type="unfinished"/>
+      <translation>開始</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/md5-database-converter/md5-database-converter.ui" line="85"/>
       <source>Cancel</source>
-      <translation type="unfinished"/>
+      <translation>取消</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/md5-database-converter/md5-database-converter.cpp" line="18"/>
       <source>You are not using a TXT MD5 database.</source>
-      <translation type="unfinished"/>
+      <translation>您並未使用 TXT MD5 資料庫。</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/md5-database-converter/md5-database-converter.cpp" line="63"/>
       <source>Finished</source>
-      <translation type="unfinished"/>
+      <translation>已完成</translation>
     </message>
     <message numerus="yes">
       <location filename="../gui/src/utils/md5-database-converter/md5-database-converter.cpp" line="63"/>
       <source>%n md5(s) converted (out of %1)</source>
-      <translation type="unfinished"/>
+      <translation>
+        <numerusform>%n 個 md5 已轉換 (%1)</numerusform>
+      </translation>
     </message>
   </context>
   <context>
@@ -1882,7 +1909,7 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/utils/md5-fix/md5-fix.ui" line="14"/>
       <source>Md5 list fixer</source>
-      <translation type="unfinished"/>
+      <translation>Md5 列表修復</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/md5-fix/md5-fix.ui" line="27"/>
@@ -1892,62 +1919,64 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/utils/md5-fix/md5-fix.ui" line="37"/>
       <source>Folder</source>
-      <translation type="unfinished"/>
+      <translation>文件夾</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/md5-fix/md5-fix.ui" line="47"/>
       <source>Force md5 calculation</source>
-      <translation type="unfinished"/>
+      <translation>強制進行 md5 計算</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/md5-fix/md5-fix.ui" line="54"/>
       <source>Get md5 in filename</source>
-      <translation type="unfinished"/>
+      <translation>通過檔案名獲取 md5</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/md5-fix/md5-fix.ui" line="64"/>
       <source>Filename</source>
-      <translation type="unfinished"/>
+      <translation>檔案名</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/md5-fix/md5-fix.ui" line="77"/>
       <source>%v/%m</source>
-      <translation type="unfinished"/>
+      <translation>%v/%m</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/md5-fix/md5-fix.ui" line="99"/>
       <source>Start</source>
-      <translation type="unfinished"/>
+      <translation>開始</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/md5-fix/md5-fix.ui" line="106"/>
       <source>Cancel</source>
-      <translation type="unfinished"/>
+      <translation>取消</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/md5-fix/md5-fix.ui" line="115"/>
       <source>Suffixes</source>
-      <translation type="unfinished"/>
+      <translation>後綴</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/md5-fix/md5-fix.cpp" line="93"/>
       <source>This folder does not exist.</source>
-      <translation type="unfinished"/>
+      <translation>這個文件夾不存在。</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/md5-fix/md5-fix.cpp" line="101"/>
       <source>If you want to get the MD5 from the filename, you have to include the %md5% token in it.</source>
-      <translation type="unfinished"/>
+      <translation>如果你想要從檔案名獲得 MD5，你必須先添加 %md5% 變數到檔案名中。</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/md5-fix/md5-fix.cpp" line="83"/>
       <source>Finished</source>
-      <translation type="unfinished"/>
+      <translation>已完成</translation>
     </message>
     <message numerus="yes">
       <location filename="../gui/src/utils/md5-fix/md5-fix.cpp" line="83"/>
       <source>%n MD5(s) loaded</source>
-      <translation type="unfinished"/>
+      <translation>
+        <numerusform>%n 個 MD5 被載入</numerusform>
+      </translation>
     </message>
   </context>
   <context>
@@ -1968,17 +1997,17 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/monitor-table-model.cpp" line="45"/>
       <source>Search</source>
-      <translation type="unfinished"/>
+      <translation>搜索</translation>
     </message>
     <message>
       <location filename="../gui/src/monitor-table-model.cpp" line="46"/>
       <source>Source</source>
-      <translation type="unfinished"/>
+      <translation>來源</translation>
     </message>
     <message>
       <location filename="../gui/src/monitor-table-model.cpp" line="47"/>
       <source>Interval</source>
-      <translation type="unfinished"/>
+      <translation>間隔</translation>
     </message>
     <message>
       <location filename="../gui/src/monitor-table-model.cpp" line="48"/>
@@ -1993,12 +2022,12 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/monitor-table-model.cpp" line="50"/>
       <source>Last check</source>
-      <translation type="unfinished"/>
+      <translation>上次檢查</translation>
     </message>
     <message>
       <location filename="../gui/src/monitor-table-model.cpp" line="51"/>
       <source>Next check</source>
-      <translation type="unfinished"/>
+      <translation>下次檢查</translation>
     </message>
     <message>
       <location filename="../gui/src/monitor-table-model.cpp" line="52"/>
@@ -2023,7 +2052,9 @@ Please solve the issue before resuming the download.</source>
     <message numerus="yes">
       <location filename="../gui/src/monitor-table-model.cpp" line="180"/>
       <source>%n time(s)</source>
-      <translation type="unfinished"/>
+      <translation>
+        <numerusform>%n 次</numerusform>
+      </translation>
     </message>
   </context>
   <context>
@@ -2031,109 +2062,109 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/monitor-window.ui" line="20"/>
       <source>Edit a monitor</source>
-      <translation type="unfinished"/>
+      <translation>編輯監控</translation>
     </message>
     <message>
       <location filename="../gui/src/monitor-window.ui" line="34"/>
       <source>General</source>
-      <translation type="unfinished"/>
+      <translation>常規​​​​​</translation>
     </message>
     <message>
       <location filename="../gui/src/monitor-window.ui" line="40"/>
       <source>Tag corresponding to the favorite. It is not often useful to change it.</source>
-      <translation type="unfinished"/>
+      <translation>標籤和收藏相對應。大部分時候不需要修改。</translation>
     </message>
     <message>
       <location filename="../gui/src/monitor-window.ui" line="43"/>
       <source>Search</source>
-      <translation type="unfinished"/>
+      <translation>搜索</translation>
     </message>
     <message>
       <location filename="../gui/src/monitor-window.ui" line="53"/>
       <source>Last time you clicked on "Mark as viewed".</source>
-      <translation type="unfinished"/>
+      <translation>上一次你選擇”標記為看過“。</translation>
     </message>
     <message>
       <location filename="../gui/src/monitor-window.ui" line="56"/>
       <source>Last check</source>
-      <translation type="unfinished"/>
+      <translation>上次檢查</translation>
     </message>
     <message>
       <location filename="../gui/src/monitor-window.ui" line="76"/>
       <source>Sources</source>
-      <translation type="unfinished"/>
+      <translation>來源</translation>
     </message>
     <message>
       <location filename="../gui/src/monitor-window.ui" line="83"/>
       <source>Interval</source>
-      <translation type="unfinished"/>
+      <translation>間隔</translation>
     </message>
     <message>
       <location filename="../gui/src/monitor-window.ui" line="90"/>
       <location filename="../gui/src/monitor-window.ui" line="127"/>
       <source> min</source>
-      <translation type="unfinished"/>
+      <translation> 分鐘</translation>
     </message>
     <message>
       <location filename="../gui/src/monitor-window.ui" line="100"/>
       <source>Post-filters</source>
-      <translation type="unfinished"/>
+      <translation>後過濾</translation>
     </message>
     <message>
       <location filename="../gui/src/monitor-window.ui" line="113"/>
       <source>Edit sources</source>
-      <translation type="unfinished"/>
+      <translation>編輯來源</translation>
     </message>
     <message>
       <location filename="../gui/src/monitor-window.ui" line="120"/>
       <source>Delay</source>
-      <translation type="unfinished"/>
+      <translation>延遲</translation>
     </message>
     <message>
       <location filename="../gui/src/monitor-window.ui" line="138"/>
       <source>Notification</source>
-      <translation type="unfinished"/>
+      <translation>通知</translation>
     </message>
     <message>
       <location filename="../gui/src/monitor-window.ui" line="144"/>
       <location filename="../gui/src/monitor-window.ui" line="161"/>
       <source>Enabled</source>
-      <translation type="unfinished"/>
+      <translation>啟用</translation>
     </message>
     <message>
       <location filename="../gui/src/monitor-window.ui" line="155"/>
       <source>Download</source>
-      <translation type="unfinished"/>
+      <translation>下載</translation>
     </message>
     <message>
       <location filename="../gui/src/monitor-window.ui" line="168"/>
       <source>Path</source>
-      <translation type="unfinished"/>
+      <translation>路徑</translation>
     </message>
     <message>
       <location filename="../gui/src/monitor-window.ui" line="175"/>
       <source>Filename</source>
-      <translation type="unfinished"/>
+      <translation>檔案名</translation>
     </message>
     <message>
       <location filename="../gui/src/monitor-window.ui" line="190"/>
       <source>Leave empty to use default settings.</source>
-      <translation type="unfinished"/>
+      <translation>留空將使用默認設置</translation>
     </message>
     <message>
       <location filename="../gui/src/monitor-window.ui" line="197"/>
       <source>Download blacklisted images</source>
-      <translation type="unfinished"/>
+      <translation>下載黑名單中的圖片</translation>
     </message>
     <message>
       <location filename="../gui/src/monitor-window.cpp" line="42"/>
       <source>You need to enable the system tray icon to use notifications.</source>
-      <translation type="unfinished"/>
+      <translation>您需要啟用系統托盤圖示才能使用通知</translation>
     </message>
     <message>
       <location filename="../gui/src/monitor-window.cpp" line="53"/>
       <source>Choose a save folder</source>
-      <translation type="unfinished"/>
+      <translation>選擇保存的文件夾</translation>
     </message>
   </context>
   <context>
@@ -2141,17 +2172,21 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../lib/src/monitoring/monitoring-center.cpp" line="105"/>
       <source>New images found for tag '%1' on '%2'</source>
-      <translation type="unfinished"/>
+      <translation>在 '%2' 上發現標籤 '%1' 的新圖片</translation>
     </message>
     <message numerus="yes">
       <location filename="../lib/src/monitoring/monitoring-center.cpp" line="107"/>
       <source>%n new image(s) found for tag '%1' on '%2'</source>
-      <translation type="unfinished"/>
+      <translation>
+        <numerusform>在 '%2' 上發現 %n 張標籤 '%1' 的新圖片</numerusform>
+      </translation>
     </message>
     <message numerus="yes">
       <location filename="../lib/src/monitoring/monitoring-center.cpp" line="109"/>
       <source>More than %n new image(s) found for tag '%1' on '%2'</source>
-      <translation type="unfinished"/>
+      <translation>
+        <numerusform>在 '%2' 上發現多於 %n 張標籤 '%1' 的新圖片</numerusform>
+      </translation>
     </message>
   </context>
   <context>
@@ -2159,24 +2194,24 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/tabs/monitors-tab.ui" line="26"/>
       <source>Monitors</source>
-      <translation type="unfinished"/>
+      <translation>監視</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/monitors-tab.ui" line="54"/>
       <location filename="../gui/src/tabs/monitors-tab.cpp" line="157"/>
       <source>Stop</source>
-      <translation type="unfinished"/>
+      <translation>停止</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/monitors-tab.ui" line="61"/>
       <location filename="../gui/src/tabs/monitors-tab.cpp" line="85"/>
       <source>Start now</source>
-      <translation type="unfinished"/>
+      <translation>立即運行</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/monitors-tab.cpp" line="83"/>
       <source>Edit</source>
-      <translation type="unfinished"/>
+      <translation>編輯</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/monitors-tab.cpp" line="84"/>
@@ -2186,12 +2221,12 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/tabs/monitors-tab.cpp" line="87"/>
       <source>Remove</source>
-      <translation type="unfinished"/>
+      <translation>刪除</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/monitors-tab.cpp" line="157"/>
       <source>Start</source>
-      <translation type="unfinished"/>
+      <translation>開始</translation>
     </message>
   </context>
   <context>
@@ -2199,17 +2234,17 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="14"/>
       <source>Options</source>
-      <translation type="unfinished"/>
+      <translation>選項</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="49"/>
       <source>General</source>
-      <translation type="unfinished"/>
+      <translation>一般</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="54"/>
       <source>Sources</source>
-      <translation type="unfinished"/>
+      <translation>來源</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="64"/>
@@ -2218,191 +2253,191 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/settings/options-window.ui" line="3476"/>
       <location filename="../gui/src/settings/options-window.ui" line="4504"/>
       <source>Save</source>
-      <translation type="unfinished"/>
+      <translation>保存</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="68"/>
       <source>Filename</source>
-      <translation type="unfinished"/>
+      <translation>檔案名</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="73"/>
       <source>Conditional filenames</source>
-      <translation type="unfinished"/>
+      <translation>條件檔案名</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="78"/>
       <source>Separate log files</source>
-      <translation type="unfinished"/>
+      <translation>單獨的日誌檔案</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="88"/>
       <source>Custom token</source>
-      <translation type="unfinished"/>
+      <translation>自訂變數</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="109"/>
       <source>Interface</source>
-      <translation type="unfinished"/>
+      <translation>界面</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="117"/>
       <source>Search results</source>
-      <translation type="unfinished"/>
+      <translation>搜索結果</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="128"/>
       <source>Image window</source>
-      <translation type="unfinished"/>
+      <translation>圖像瀏覽窗口</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="143"/>
       <source>Coloring</source>
-      <translation type="unfinished"/>
+      <translation>顏色</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="148"/>
       <source>Margins and borders</source>
-      <translation type="unfinished"/>
+      <translation>距離和邊框</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="153"/>
       <source>Log</source>
-      <translation type="unfinished"/>
+      <translation>日誌</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="159"/>
       <source>Blacklist</source>
-      <translation type="unfinished"/>
+      <translation>黑名單</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="169"/>
       <source>Monitoring</source>
-      <translation type="unfinished"/>
+      <translation>監控</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="174"/>
       <source>Proxy</source>
-      <translation type="unfinished"/>
+      <translation>代理</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="179"/>
       <source>Web services</source>
-      <translation type="unfinished"/>
+      <translation>在線服務</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="184"/>
       <location filename="../gui/src/settings/options-window.ui" line="5815"/>
       <source>Commands</source>
-      <translation type="unfinished"/>
+      <translation>命令行</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="188"/>
       <location filename="../gui/src/settings/options-window.ui" line="5927"/>
       <source>Database</source>
-      <translation type="unfinished"/>
+      <translation>資料庫</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="216"/>
       <source>Language</source>
-      <translation type="unfinished"/>
+      <translation>語言</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="226"/>
       <source>At start</source>
-      <translation type="unfinished"/>
+      <translation>啟動時</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="234"/>
       <location filename="../gui/src/settings/options-window.ui" line="825"/>
       <source>Do nothing</source>
-      <translation type="unfinished"/>
+      <translation>什麼都不做</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="239"/>
       <source>Load first page</source>
-      <translation type="unfinished"/>
+      <translation>載入第一頁</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="244"/>
       <source>Restore last session</source>
-      <translation type="unfinished"/>
+      <translation>恢復上次會話</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="252"/>
       <source>Check for updates</source>
-      <translation type="unfinished"/>
+      <translation>檢查更新</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="263"/>
       <source>Every time</source>
-      <translation type="unfinished"/>
+      <translation>每次啟動</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="268"/>
       <source>Once a day</source>
-      <translation type="unfinished"/>
+      <translation>每天</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="273"/>
       <source>Once a week</source>
-      <translation type="unfinished"/>
+      <translation>每週</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="278"/>
       <source>Once a month</source>
-      <translation type="unfinished"/>
+      <translation>每月</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="283"/>
       <source>Never</source>
-      <translation type="unfinished"/>
+      <translation>從不</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="291"/>
       <source>Whitelist</source>
-      <translation type="unfinished"/>
+      <translation>白名單</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="301"/>
       <source>Download</source>
-      <translation type="unfinished"/>
+      <translation>下載原圖</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="312"/>
       <source>Don't download automatically</source>
-      <translation type="unfinished"/>
+      <translation>不要自動下載</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="317"/>
       <source>When loading image</source>
-      <translation type="unfinished"/>
+      <translation>載入圖片時</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="322"/>
       <source>When loading thumbnail</source>
-      <translation type="unfinished"/>
+      <translation>載入縮圖時</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="335"/>
       <source>Images containing a whitelisted tag will be downloaded automatically according to the option above.</source>
-      <translation type="unfinished"/>
+      <translation>如果圖片有在白名單中的標籤，啟用這個選項將會自動下載。</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="164"/>
       <location filename="../gui/src/settings/options-window.ui" line="5435"/>
       <source>Ignored tags</source>
-      <translation type="unfinished"/>
+      <translation>忽略的標籤</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5399"/>
       <source>Download images containing blacklisted tags</source>
-      <translation type="unfinished"/>
+      <translation>下載包含黑名單中標籤的圖片</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="345"/>
       <source>Adds</source>
-      <translation type="unfinished"/>
+      <translation>追加標籤</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="58"/>
@@ -2412,7 +2447,7 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="132"/>
       <source>Buttons</source>
-      <translation type="unfinished"/>
+      <translation>按鈕</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="194"/>
@@ -2422,47 +2457,47 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="387"/>
       <source>Ask for confirmation before closing the window</source>
-      <translation type="unfinished"/>
+      <translation>關閉窗口前確認</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="394"/>
       <source>Send anonymous usage data</source>
-      <translation type="unfinished"/>
+      <translation>發送匿名用量數據</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="438"/>
       <source>Images per page</source>
-      <translation type="unfinished"/>
+      <translation>每頁圖片數</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="445"/>
       <source>Number of columns</source>
-      <translation type="unfinished"/>
+      <translation>列數</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="452"/>
       <source>Source 1</source>
-      <translation type="unfinished"/>
+      <translation>來源 1</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="459"/>
       <source>Source 2</source>
-      <translation type="unfinished"/>
+      <translation>來源 2</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="466"/>
       <source>Source 3</source>
-      <translation type="unfinished"/>
+      <translation>來源 3</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="473"/>
       <source>Source 4</source>
-      <translation type="unfinished"/>
+      <translation>來源 4</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="506"/>
       <source>Get more precise tags when searching images</source>
-      <translation type="unfinished"/>
+      <translation>在搜索圖片時獲取更精確的標籤</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="517"/>
@@ -2470,7 +2505,7 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/settings/options-window.ui" line="571"/>
       <location filename="../gui/src/settings/options-window.ui" line="598"/>
       <source>XML</source>
-      <translation type="unfinished"/>
+      <translation>XML</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="522"/>
@@ -2478,7 +2513,7 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/settings/options-window.ui" line="576"/>
       <location filename="../gui/src/settings/options-window.ui" line="603"/>
       <source>JSON</source>
-      <translation type="unfinished"/>
+      <translation>JSON</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="527"/>
@@ -2486,7 +2521,7 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/settings/options-window.ui" line="581"/>
       <location filename="../gui/src/settings/options-window.ui" line="608"/>
       <source>Regex</source>
-      <translation type="unfinished"/>
+      <translation>正則表達式</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="532"/>
@@ -2494,12 +2529,12 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/settings/options-window.ui" line="586"/>
       <location filename="../gui/src/settings/options-window.ui" line="613"/>
       <source>RSS</source>
-      <translation type="unfinished"/>
+      <translation>RSS</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="621"/>
       <source>Auto tag add</source>
-      <translation type="unfinished"/>
+      <translation>自動添加標籤</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="671"/>
@@ -2514,140 +2549,140 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="711"/>
       <source>Download original images</source>
-      <translation type="unfinished"/>
+      <translation>下載原圖</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="721"/>
       <source>Download sample on error</source>
-      <translation type="unfinished"/>
+      <translation>發生錯誤時下載縮圖</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="731"/>
       <source>Download images automatically</source>
-      <translation type="unfinished"/>
+      <translation>自動下載圖片</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="738"/>
       <source>Keep original creation date</source>
-      <translation type="unfinished"/>
+      <translation>保留原始創建時間</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="748"/>
       <source>Get extension from file header</source>
-      <translation type="unfinished"/>
+      <translation>從文件頭讀取副檔名</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="758"/>
       <source>Folder</source>
-      <translation type="unfinished"/>
+      <translation>文件夾</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="770"/>
       <location filename="../gui/src/settings/options-window.ui" line="791"/>
       <location filename="../gui/src/settings/options-window.ui" line="966"/>
       <source>Browse</source>
-      <translation type="unfinished"/>
+      <translation>瀏覽</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="779"/>
       <location filename="../gui/src/settings/options-window.ui" line="1043"/>
       <location filename="../gui/src/settings/options-window.ui" line="5004"/>
       <source>Favorites</source>
-      <translation type="unfinished"/>
+      <translation>收藏</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="800"/>
       <source>Simultaneous downloads</source>
-      <translation type="unfinished"/>
+      <translation>同時下載數</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="817"/>
       <source>When the download is finished</source>
-      <translation type="unfinished"/>
+      <translation>下載完成時</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="830"/>
       <source>Close window</source>
-      <translation type="unfinished"/>
+      <translation>關閉窗口</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="835"/>
       <source>Open CD tray</source>
-      <translation type="unfinished"/>
+      <translation>彈出光碟機</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="840"/>
       <source>Play a sound</source>
-      <translation type="unfinished"/>
+      <translation>播放提示音</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="845"/>
       <source>Shutdown</source>
-      <translation type="unfinished"/>
+      <translation>關機</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="853"/>
       <source>If a file already exists globally</source>
-      <translation type="unfinished"/>
+      <translation>若全局範圍內文件已存在</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="869"/>
       <location filename="../gui/src/settings/options-window.ui" line="931"/>
       <location filename="../gui/src/settings/options-window.ui" line="988"/>
       <source>Copy</source>
-      <translation type="unfinished"/>
+      <translation>複製</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="874"/>
       <location filename="../gui/src/settings/options-window.ui" line="993"/>
       <source>Move</source>
-      <translation type="unfinished"/>
+      <translation>移動</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="879"/>
       <location filename="../gui/src/settings/options-window.ui" line="998"/>
       <source>Don't save</source>
-      <translation type="unfinished"/>
+      <translation>不要保存</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="892"/>
       <source>File's identity is based on the MD5 algorithm.</source>
-      <translation type="unfinished"/>
+      <translation>文件的身份識別基於 MD5 值。</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="916"/>
       <source>Keep deleted files in the MD5 list</source>
-      <translation type="unfinished"/>
+      <translation>保留已刪除的文件的 MD5</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="923"/>
       <source>If an image yields multiple files</source>
-      <translation type="unfinished"/>
+      <translation>如果一張圖片生成多個文件</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1010"/>
       <source>Default</source>
-      <translation type="unfinished"/>
+      <translation>默認</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1076"/>
       <source>Tags separator</source>
-      <translation type="unfinished"/>
+      <translation>標籤分隔器</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1090"/>
       <source>Replace spaces by underscores</source>
-      <translation type="unfinished"/>
+      <translation>用下劃線代替空格</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1097"/>
       <source>Replace JPEG by JPG</source>
-      <translation type="unfinished"/>
+      <translation>替換 JPEG 為 JPG</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1107"/>
       <source>Max length</source>
-      <translation type="unfinished"/>
+      <translation>最大長度</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1145"/>
@@ -2657,198 +2692,198 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1155"/>
       <source>Add a conditional filename</source>
-      <translation type="unfinished"/>
+      <translation>添加一個條件檔案名</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1239"/>
       <source>Each time an image is saved, its information can be added to a separate text file for later processing or for organization purposes.</source>
-      <translation type="unfinished"/>
+      <translation>每當圖片保存時，一個文本文件將儲存在相同的地方，包含這個圖片的標籤。</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1252"/>
       <source>Add a separate log file</source>
-      <translation type="unfinished"/>
+      <translation>添加一個單獨的日誌檔案</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1276"/>
       <source>Windows Property System</source>
-      <translation type="unfinished"/>
+      <translation>Windows 屬性系統</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1292"/>
       <location filename="../gui/src/settings/options-window.ui" line="1345"/>
       <source>Add new property</source>
-      <translation type="unfinished"/>
+      <translation>添加新屬性</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1282"/>
       <location filename="../gui/src/settings/options-window.ui" line="1332"/>
       <source>Extensions</source>
-      <translation type="unfinished"/>
+      <translation>擴展組件</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1312"/>
       <source>Exiftool</source>
-      <translation type="unfinished"/>
+      <translation>Exiftool</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1318"/>
       <source>Version</source>
-      <translation type="unfinished"/>
+      <translation>版本</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1325"/>
       <location filename="../gui/src/settings/options-window.ui" line="1520"/>
       <location filename="../gui/src/settings/options-window.ui" line="1534"/>
       <source>Loading...</source>
-      <translation type="unfinished"/>
+      <translation>載入中……</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1420"/>
       <source>Add a custom token</source>
-      <translation type="unfinished"/>
+      <translation>添加自訂變數</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1432"/>
       <source>Resize</source>
-      <translation type="unfinished"/>
+      <translation>縮放</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1438"/>
       <source>Max width</source>
-      <translation type="unfinished"/>
+      <translation>最大寬度</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1458"/>
       <source>Max height</source>
-      <translation type="unfinished"/>
+      <translation>最大高度</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1483"/>
       <source>Images bigger than the max width and/or height will be resized to fit.</source>
-      <translation type="unfinished"/>
+      <translation>大於最大寬度和/或高度的圖像將根據需要調整大小。</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1748"/>
       <source>Theme</source>
-      <translation type="unfinished"/>
+      <translation>主題</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1765"/>
       <source>%</source>
-      <translation type="unfinished"/>
+      <translation>%</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1788"/>
       <source>Favorites display</source>
-      <translation type="unfinished"/>
+      <translation>收藏顯示</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1796"/>
       <source>Image, name and details</source>
-      <translation type="unfinished"/>
+      <translation>圖片，名稱和詳情</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1801"/>
       <source>Image and name</source>
-      <translation type="unfinished"/>
+      <translation>圖片和名稱</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1806"/>
       <source>Image and details</source>
-      <translation type="unfinished"/>
+      <translation>圖片和詳情</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1811"/>
       <source>Name and details</source>
-      <translation type="unfinished"/>
+      <translation>名稱和詳情</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1816"/>
       <source>Image only</source>
-      <translation type="unfinished"/>
+      <translation>僅圖片</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1821"/>
       <source>Name only</source>
-      <translation type="unfinished"/>
+      <translation>只有名字</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1826"/>
       <source>Details only</source>
-      <translation type="unfinished"/>
+      <translation>僅詳情</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1834"/>
       <source>Hide favorites</source>
-      <translation type="unfinished"/>
+      <translation>隱藏收藏</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1856"/>
       <source>The favorites list will be hidden as soon as this image number has been reached.</source>
-      <translation type="unfinished"/>
+      <translation>當到達特定圖片數時，收藏列表將被隱藏。</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1866"/>
       <source>Source's type display</source>
-      <translation type="unfinished"/>
+      <translation>來源類型顯示</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1874"/>
       <source>Text</source>
-      <translation type="unfinished"/>
+      <translation>文本</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1879"/>
       <location filename="../gui/src/settings/options-window.ui" line="5761"/>
       <location filename="../gui/src/settings/options-window.ui" line="5841"/>
       <source>Image</source>
-      <translation type="unfinished"/>
+      <translation>圖片</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1884"/>
       <source>Image and text</source>
-      <translation type="unfinished"/>
+      <translation>圖片和文本</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1889"/>
       <source>Don't show</source>
-      <translation type="unfinished"/>
+      <translation>不顯示</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1897"/>
       <source>Displayed letters</source>
-      <translation type="unfinished"/>
+      <translation>顯示的字母</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1907"/>
       <source>Display n letters</source>
-      <translation type="unfinished"/>
+      <translation>顯示 n 個字母</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1912"/>
       <source>Before first dot</source>
-      <translation type="unfinished"/>
+      <translation>在第一個點前</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1917"/>
       <source>Before last dot</source>
-      <translation type="unfinished"/>
+      <translation>在最後一個點前</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1945"/>
       <source>Number of displayed letters near the sources' checkboxes in the "+" part of the main window.</source>
-      <translation type="unfinished"/>
+      <translation>在主頁面 ”+“ 的來源複選框旁顯示的字母數量.</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1955"/>
       <source>Preload all tabs when restoring a previous session</source>
-      <translation type="unfinished"/>
+      <translation>恢復上次會話時預載入所有標籤</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1986"/>
       <source>Decline dialogue</source>
-      <translation type="unfinished"/>
+      <translation>對話框拒絕快捷鍵</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2154"/>
@@ -2941,33 +2976,33 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/settings/options-window.ui" line="1979"/>
       <location filename="../gui/src/settings/options-window.ui" line="1993"/>
       <source>Ctrl+N</source>
-      <translation type="unfinished"/>
+      <translation>Ctrl+N</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1972"/>
       <source>Accept dialogue</source>
-      <translation type="unfinished"/>
+      <translation>對話框接受快捷鍵</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2017"/>
       <source>Use a scroll area</source>
-      <translation type="unfinished"/>
+      <translation>界面可滾動</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2027"/>
       <source>Use a fixed-image-width layout</source>
-      <translation type="unfinished"/>
+      <translation>固定圖片預覽大小</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2037"/>
       <source>Infinite scroll</source>
-      <translation type="unfinished"/>
+      <translation>無限滾動</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1383"/>
       <location filename="../gui/src/settings/options-window.ui" line="2045"/>
       <source>Disabled</source>
-      <translation type="unfinished"/>
+      <translation>禁用</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="103"/>
@@ -3103,133 +3138,133 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2050"/>
       <source>Button</source>
-      <translation type="unfinished"/>
+      <translation>按鈕翻頁</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2055"/>
       <source>Scroll</source>
-      <translation type="unfinished"/>
+      <translation>滾輪翻頁</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2063"/>
       <source>Remember page number when infinite scrolling</source>
-      <translation type="unfinished"/>
+      <translation>無限滾動時記住頁碼</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2070"/>
       <source>Resize previews instead of cropping them</source>
-      <translation type="unfinished"/>
+      <translation>重設預覽圖大小而不是裁剪</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2080"/>
       <source>Enable autocompletion</source>
-      <translation type="unfinished"/>
+      <translation>啟用自動補全</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2090"/>
       <source>Show warning if an incompatible modifier is found</source>
-      <translation type="unfinished"/>
+      <translation>當檢測到不相容的修改時顯示警告</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2100"/>
       <source>Show other warnings</source>
-      <translation type="unfinished"/>
+      <translation>顯示其它警告</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2110"/>
       <source>Download not loaded pages</source>
-      <translation type="unfinished"/>
+      <translation>下載沒有載入的頁面</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2122"/>
       <source>If you activate this option, pressing the "Get this page" button will take into account modifications made to the number of images per page, the page number, etc. even if they weren't loaded.</source>
-      <translation type="unfinished"/>
+      <translation>如果你啟用了這個選項，點擊”獲取此頁“按鈕將會對每頁顯示的圖片數和頁面數等等進行修改，無論他們是否已經被載入。</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2132"/>
       <source>Invert Click and Ctrl+Click actions</source>
-      <translation type="unfinished"/>
+      <translation>交換 左鍵單擊 和 Ctrl+左鍵單擊 操作</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2144"/>
       <source>With this option enabled, clicking an image will mark it for download, while Ctrl+Click will open the details window.</source>
-      <translation type="unfinished"/>
+      <translation>啟用此選項，左鍵單擊圖片時會將其加入下載列表，Ctrl + 左鍵單擊將會打開詳情窗口</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2204"/>
       <source>Quit application</source>
-      <translation type="unfinished"/>
+      <translation>退出應用程式</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2219"/>
       <source>Ctrl+Q</source>
-      <translation type="unfinished"/>
+      <translation>Ctrl+Q</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2235"/>
       <source>Focus search field</source>
-      <translation type="unfinished"/>
+      <translation>聚焦於搜索框</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2247"/>
       <location filename="../gui/src/settings/options-window.ui" line="4516"/>
       <source>S</source>
-      <translation type="unfinished"/>
+      <translation>S</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2263"/>
       <source>Close tab</source>
-      <translation type="unfinished"/>
+      <translation>關閉標籤頁</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2275"/>
       <source>Ctrl+W</source>
-      <translation type="unfinished"/>
+      <translation>Ctrl+W</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2291"/>
       <source>New tab</source>
-      <translation type="unfinished"/>
+      <translation>新標籤頁</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2303"/>
       <source>Ctrl+T</source>
-      <translation type="unfinished"/>
+      <translation>Ctrl+T</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2319"/>
       <source>Open previous tab</source>
-      <translation type="unfinished"/>
+      <translation>打開上一個標籤頁</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2331"/>
       <source>Ctrl+Shift+Tab</source>
-      <translation type="unfinished"/>
+      <translation>Ctrl+Shift+Tab</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2347"/>
       <source>Open next tab</source>
-      <translation type="unfinished"/>
+      <translation>打開下一個標籤頁</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2359"/>
       <source>Ctrl+Tab</source>
-      <translation type="unfinished"/>
+      <translation>Ctrl+Tab</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2447"/>
       <source>Call external application to browse save directory</source>
-      <translation type="unfinished"/>
+      <translation>調用外部程序以瀏覽保存目錄</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2459"/>
       <source>Ctrl+O</source>
-      <translation type="unfinished"/>
+      <translation>Ctrl+O</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2515"/>
       <source>Tag list position</source>
-      <translation type="unfinished"/>
+      <translation>標籤列表位置</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2523"/>
@@ -3237,7 +3272,7 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/settings/options-window.ui" line="2696"/>
       <location filename="../gui/src/settings/options-window.ui" line="2751"/>
       <source>Top</source>
-      <translation type="unfinished"/>
+      <translation>頂部</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2528"/>
@@ -3246,68 +3281,68 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/settings/options-window.ui" line="2773"/>
       <location filename="../gui/src/settings/options-window.ui" line="4404"/>
       <source>Left</source>
-      <translation type="unfinished"/>
+      <translation>左側</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2533"/>
       <source>Auto</source>
-      <translation type="unfinished"/>
+      <translation>自動</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2541"/>
       <source>Preloading</source>
-      <translation type="unfinished"/>
+      <translation>預載圖片數</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2551"/>
       <source>Slideshow</source>
-      <translation type="unfinished"/>
+      <translation>幻燈片切換時間</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2558"/>
       <source>s</source>
-      <translation type="unfinished"/>
+      <translation> 秒</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2568"/>
       <source>Middle click to close window</source>
-      <translation type="unfinished"/>
+      <translation>滑鼠中鍵單擊關閉窗口</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2578"/>
       <source>Enable scroll wheel navigation</source>
-      <translation type="unfinished"/>
+      <translation>啟用滑鼠滾輪導航</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2595"/>
       <source>Show tag count</source>
-      <translation type="unfinished"/>
+      <translation>顯示標籤順序</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2602"/>
       <source>Tag order</source>
-      <translation type="unfinished"/>
+      <translation>標籤排序方式</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2610"/>
       <location filename="../gui/src/settings/options-window.ui" line="5628"/>
       <source>Type</source>
-      <translation type="unfinished"/>
+      <translation>類型</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2615"/>
       <source>Name</source>
-      <translation type="unfinished"/>
+      <translation>名稱</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2620"/>
       <source>Count</source>
-      <translation type="unfinished"/>
+      <translation>計數</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2628"/>
       <source>Image position</source>
-      <translation type="unfinished"/>
+      <translation>圖片顯示位置</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2646"/>
@@ -3317,14 +3352,14 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/settings/options-window.ui" line="2756"/>
       <location filename="../gui/src/settings/options-window.ui" line="2778"/>
       <source>Center</source>
-      <translation type="unfinished"/>
+      <translation>居中</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2651"/>
       <location filename="../gui/src/settings/options-window.ui" line="2706"/>
       <location filename="../gui/src/settings/options-window.ui" line="2761"/>
       <source>Bottom</source>
-      <translation type="unfinished"/>
+      <translation>底部對齊</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2673"/>
@@ -3332,22 +3367,22 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/settings/options-window.ui" line="2783"/>
       <location filename="../gui/src/settings/options-window.ui" line="4432"/>
       <source>Right</source>
-      <translation type="unfinished"/>
+      <translation>右側對齊</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2683"/>
       <source>Animation position</source>
-      <translation type="unfinished"/>
+      <translation>動畫顯示位置</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2738"/>
       <source>Video position</source>
-      <translation type="unfinished"/>
+      <translation>影片顯示位置</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2793"/>
       <source>Background color</source>
-      <translation type="unfinished"/>
+      <translation>背景顏色</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2805"/>
@@ -3368,216 +3403,216 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/settings/options-window.ui" line="5242"/>
       <location filename="../gui/src/settings/options-window.ui" line="5264"/>
       <source>Color</source>
-      <translation type="unfinished"/>
+      <translation>顏色</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2508"/>
       <source>Use a single image window</source>
-      <translation type="unfinished"/>
+      <translation>只顯示單張圖片</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="93"/>
       <location filename="../gui/src/settings/options-window.ui" line="5013"/>
       <location filename="../gui/src/settings/options-window.ui" line="5101"/>
       <source>Tags</source>
-      <translation type="unfinished"/>
+      <translation>標籤</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="370"/>
       <source>These tags and post-filters will be automatically added to every search.</source>
-      <translation type="unfinished"/>
+      <translation>這些標籤或過濾器將會自動加入每次搜索的參數中</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="355"/>
       <source>Post-filters</source>
-      <translation type="unfinished"/>
+      <translation>後過濾器</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="83"/>
       <source>Metadata</source>
-      <translation type="unfinished"/>
+      <translation>元數據</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="98"/>
       <source>Image size</source>
-      <translation type="unfinished"/>
+      <translation>圖像大小</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="113"/>
       <source>Main window</source>
-      <translation type="unfinished"/>
+      <translation>主窗口</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="122"/>
       <location filename="../gui/src/settings/options-window.ui" line="137"/>
       <source>Shortcuts</source>
-      <translation type="unfinished"/>
+      <translation>快捷鍵</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="380"/>
       <source>Explicitely add global post-filter to tab post-filter field</source>
-      <translation type="unfinished"/>
+      <translation>將全局後過濾器顯式添加到標籤頁後過濾器區域</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="401"/>
       <source>Use system locale for dates and numbers</source>
-      <translation type="unfinished"/>
+      <translation>使用系統區域對應的日期和數位格式</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="939"/>
       <source>Temporary directory</source>
-      <translation type="unfinished"/>
+      <translation>臨時目錄</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="951"/>
       <source>Leave empty to use the default temporary directory.</source>
-      <translation type="unfinished"/>
+      <translation>留空將使用默認臨時文件夾。</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="975"/>
       <source>If it's in the same directory</source>
-      <translation type="unfinished"/>
+      <translation>如果文件在同一目錄中</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1126"/>
       <source>If the filename length is greater than this number, it will be shortened. Leave it to 0 to use the default limit. Don't go above 260 on Windows unless you know what you're doing.</source>
-      <translation type="unfinished"/>
+      <translation>檔案名長度若大於此數字，將被縮短。如果您不知道這個選項的意義，請保持其為 0。除非您知道您在做什麼，否則請勿在 Windows 上使此值超過 260。</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2588"/>
       <source>Use image samples</source>
-      <translation type="unfinished"/>
+      <translation>顯示縮圖</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2814"/>
       <source>Scale up small images to fit window</source>
-      <translation type="unfinished"/>
+      <translation>放大小圖像以適應窗口</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2821"/>
       <source>Use built-in video player</source>
-      <translation type="unfinished"/>
+      <translation>使用內建影片播放器</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2851"/>
       <source>Show video player controls</source>
-      <translation type="unfinished"/>
+      <translation>顯示影片播放器控制項</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2861"/>
       <source>Show GIF player controls</source>
-      <translation type="unfinished"/>
+      <translation>顯示 GIF 播放器控制項</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4364"/>
       <source>Close</source>
-      <translation type="unfinished"/>
+      <translation>關閉</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4376"/>
       <source>Esc</source>
-      <translation type="unfinished"/>
+      <translation>Esc</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2917"/>
       <location filename="../gui/src/settings/options-window.ui" line="4392"/>
       <source>Prev</source>
-      <translation type="unfinished"/>
+      <translation>上一頁</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="3062"/>
       <location filename="../gui/src/settings/options-window.ui" line="4420"/>
       <source>Next</source>
-      <translation type="unfinished"/>
+      <translation>下一頁</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="3198"/>
       <location filename="../gui/src/settings/options-window.ui" line="4448"/>
       <source>Details</source>
-      <translation type="unfinished"/>
+      <translation>詳情</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4460"/>
       <source>D</source>
-      <translation type="unfinished"/>
+      <translation>D</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4476"/>
       <source>Save as...</source>
-      <translation type="unfinished"/>
+      <translation>另存為...</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4488"/>
       <source>Shift+S</source>
-      <translation type="unfinished"/>
+      <translation>Shift+S</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="3615"/>
       <location filename="../gui/src/settings/options-window.ui" line="4532"/>
       <source>Save and close</source>
-      <translation type="unfinished"/>
+      <translation>保存並關閉</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4544"/>
       <source>W</source>
-      <translation type="unfinished"/>
+      <translation>W</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4560"/>
       <source>Destination folder</source>
-      <translation type="unfinished"/>
+      <translation>目標文件夾</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4572"/>
       <source>O</source>
-      <translation type="unfinished"/>
+      <translation>O</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="3893"/>
       <location filename="../gui/src/settings/options-window.ui" line="4588"/>
       <source>Save (fav)</source>
-      <translation type="unfinished"/>
+      <translation>保存 (收藏)</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4600"/>
       <source>Alt+S</source>
-      <translation type="unfinished"/>
+      <translation>Alt+S</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4032"/>
       <location filename="../gui/src/settings/options-window.ui" line="4616"/>
       <source>Save and close (fav)</source>
-      <translation type="unfinished"/>
+      <translation>保存並關閉 (收藏)</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1758"/>
       <source>Thumbnail scaling</source>
-      <translation type="unfinished"/>
+      <translation>縮圖縮放</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1962"/>
       <source>Scale font size</source>
-      <translation type="unfinished"/>
+      <translation>縮放字體大小</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2469"/>
       <source>Back out from favorites results</source>
-      <translation type="unfinished"/>
+      <translation>從收藏結果頁回退到上一級</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2831"/>
       <source>Remember button drawer state</source>
-      <translation type="unfinished"/>
+      <translation>記住按鈕抽屜狀態</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2841"/>
       <source>Remember window geometry</source>
-      <translation type="unfinished"/>
+      <translation>記住窗口位置和大小</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2914"/>
       <source>Previous media entry</source>
-      <translation type="unfinished"/>
+      <translation>上一頁媒體條目</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2929"/>
@@ -3591,7 +3626,7 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/settings/options-window.ui" line="4044"/>
       <location filename="../gui/src/settings/options-window.ui" line="4183"/>
       <source>Partial checks are stored in collapsable drawer</source>
-      <translation type="unfinished"/>
+      <translation>半選會使其被置於可摺疊的按鈕抽屜中</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2932"/>
@@ -3605,7 +3640,7 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/settings/options-window.ui" line="4047"/>
       <location filename="../gui/src/settings/options-window.ui" line="4186"/>
       <source>Enable</source>
-      <translation type="unfinished"/>
+      <translation>啟用</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2964"/>
@@ -3619,7 +3654,7 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/settings/options-window.ui" line="4079"/>
       <location filename="../gui/src/settings/options-window.ui" line="4218"/>
       <source>Ascending from left to right</source>
-      <translation type="unfinished"/>
+      <translation>從左往右升序</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="2979"/>
@@ -3633,7 +3668,7 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/settings/options-window.ui" line="4088"/>
       <location filename="../gui/src/settings/options-window.ui" line="4227"/>
       <source>Position: </source>
-      <translation type="unfinished"/>
+      <translation>位置: </translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="3008"/>
@@ -3647,7 +3682,7 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/settings/options-window.ui" line="4120"/>
       <location filename="../gui/src/settings/options-window.ui" line="4259"/>
       <source>Button display text</source>
-      <translation type="unfinished"/>
+      <translation>按鈕顯示文本</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="3040"/>
@@ -3661,7 +3696,7 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/settings/options-window.ui" line="4146"/>
       <location filename="../gui/src/settings/options-window.ui" line="4285"/>
       <source>Smaller numbers make for smaller buttons</source>
-      <translation type="unfinished"/>
+      <translation>數字越小，按鈕越小</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="3043"/>
@@ -3675,122 +3710,122 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/settings/options-window.ui" line="4149"/>
       <location filename="../gui/src/settings/options-window.ui" line="4288"/>
       <source>Width: </source>
-      <translation type="unfinished"/>
+      <translation>寬度: </translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="3059"/>
       <source>Next media entry</source>
-      <translation type="unfinished"/>
+      <translation>下一頁媒體條目</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="3195"/>
       <source>View media details</source>
-      <translation type="unfinished"/>
+      <translation>查看媒體詳情</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="3334"/>
       <source>Save file with specified path</source>
-      <translation type="unfinished"/>
+      <translation>使用指定路徑保存文件</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="3337"/>
       <source>Save As...</source>
-      <translation type="unfinished"/>
+      <translation>另存為...</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="3473"/>
       <source>Save file to usual path</source>
-      <translation type="unfinished"/>
+      <translation>保存文件到常用路徑</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="3612"/>
       <source>Save file to usual path and close the viewer window</source>
-      <translation type="unfinished"/>
+      <translation>保存文件到常用路徑並關閉查看器窗口</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="3751"/>
       <source>Open usual save path in file browser</source>
-      <translation type="unfinished"/>
+      <translation>在文件瀏覽器中打開常用保存路徑</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="3754"/>
       <source>Open</source>
-      <translation type="unfinished"/>
+      <translation>打開</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="3890"/>
       <source>Save file to favourite path</source>
-      <translation type="unfinished"/>
+      <translation>保存文件到收藏路徑</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4029"/>
       <source>Save file to favourite path and close the viewer window</source>
-      <translation type="unfinished"/>
+      <translation>保存文件到收藏路徑並關閉查看器窗口</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4168"/>
       <source>Open favourite save path in file browser</source>
-      <translation type="unfinished"/>
+      <translation>在文件瀏覽器中打開收藏保存路徑</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4171"/>
       <source>Open (fav)</source>
-      <translation type="unfinished"/>
+      <translation>打開 (收藏)</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4628"/>
       <source>Alt+W</source>
-      <translation type="unfinished"/>
+      <translation>Alt+W</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4644"/>
       <source>Destination folder (fav)</source>
-      <translation type="unfinished"/>
+      <translation>目標文件夾 (收藏)</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4656"/>
       <source>Alt+O</source>
-      <translation type="unfinished"/>
+      <translation>Alt+O</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4672"/>
       <source>Toggle full-screen</source>
-      <translation type="unfinished"/>
+      <translation>切換全螢幕顯示</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4684"/>
       <source>F11</source>
-      <translation type="unfinished"/>
+      <translation>F11</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4700"/>
       <source>Toggle slideshow</source>
-      <translation type="unfinished"/>
+      <translation>切換幻燈片</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4712"/>
       <source>Space</source>
-      <translation type="unfinished"/>
+      <translation>Space</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4728"/>
       <source>Copy raw media data to clipboard</source>
-      <translation type="unfinished"/>
+      <translation>複製原始媒體數據到剪貼簿</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4740"/>
       <source>C</source>
-      <translation type="unfinished"/>
+      <translation>C</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4750"/>
       <source>Open in browser</source>
-      <translation type="unfinished"/>
+      <translation>在瀏覽器中打開</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4776"/>
       <source>Artists</source>
-      <translation type="unfinished"/>
+      <translation>藝術家</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4799"/>
@@ -3806,119 +3841,119 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/settings/options-window.ui" line="5127"/>
       <location filename="../gui/src/settings/options-window.ui" line="5171"/>
       <source>Font</source>
-      <translation type="unfinished"/>
+      <translation>自提</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4808"/>
       <source>Circle</source>
-      <translation type="unfinished"/>
+      <translation>圓圈</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4836"/>
       <source>Series</source>
-      <translation type="unfinished"/>
+      <translation>系列</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4864"/>
       <source>Characters</source>
-      <translation type="unfinished"/>
+      <translation>角色</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4948"/>
       <source>Models</source>
-      <translation type="unfinished"/>
+      <translation>模型</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4976"/>
       <source>Generals</source>
-      <translation type="unfinished"/>
+      <translation>一般</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5092"/>
       <source>Blacklisted</source>
-      <translation type="unfinished"/>
+      <translation>已被加入黑名單</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5152"/>
       <source>Ignored</source>
-      <translation type="unfinished"/>
+      <translation>已被忽略</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4892"/>
       <source>Species</source>
-      <translation type="unfinished"/>
+      <translation>物種 (Species)</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5064"/>
       <source>Kept for later</source>
-      <translation type="unfinished"/>
+      <translation>稍後再看</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="4920"/>
       <source>Metas</source>
-      <translation type="unfinished"/>
+      <translation>元資訊 (Metas)</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5199"/>
       <source>Hosts</source>
-      <translation type="unfinished"/>
+      <translation>主機</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5205"/>
       <location filename="../gui/src/settings/options-window.ui" line="5282"/>
       <source>Horizontal margins</source>
-      <translation type="unfinished"/>
+      <translation>水平間距</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5225"/>
       <location filename="../gui/src/settings/options-window.ui" line="5316"/>
       <source>Borders</source>
-      <translation type="unfinished"/>
+      <translation>邊框</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5276"/>
       <source>Images</source>
-      <translation type="unfinished"/>
+      <translation>圖片</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5299"/>
       <source>Vertical margins</source>
-      <translation type="unfinished"/>
+      <translation>垂直間距</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5340"/>
       <source>Show log</source>
-      <translation type="unfinished"/>
+      <translation>顯示日誌</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5354"/>
       <source>Blacklisted tags</source>
-      <translation type="unfinished"/>
+      <translation>標籤黑名單</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5372"/>
       <source>One line per blacklist. You can put multiple tags on a single line to make "AND" conditions.</source>
-      <translation type="unfinished"/>
+      <translation>每行一條黑名單規則。你可以將多個標籤填入一行。</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5410"/>
       <source>Removed tags</source>
-      <translation type="unfinished"/>
+      <translation>刪除標籤</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5425"/>
       <source>These tags will not be taken in account when saving image. They won't appear in tokens such as %copyright% or %all%.</source>
-      <translation type="unfinished"/>
+      <translation>這些標籤在保存圖片時將不被考量。它們將不會出現在形如 %copyright% 或 %all% 之類的變數中。</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5450"/>
       <source>One tag per line. Ignored tags will not be treated as having any particular type, and therefore not appearing, for example, in %copyright%. They will however still appear in %all%.</source>
-      <translation type="unfinished"/>
+      <translation>每行一個標籤。被忽略的標籤將不會被認為歸屬於任何特定類別，因此不會出現在如 %copyright% 之類的變數中。雖然它們仍會出現在 %all% 中。</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5464"/>
       <source>Delay on startup</source>
-      <translation type="unfinished"/>
+      <translation>啟動時延遲</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1568"/>
@@ -3927,93 +3962,93 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/settings/options-window.ui" line="5471"/>
       <location filename="../gui/src/settings/options-window.ui" line="5788"/>
       <source> s</source>
-      <translation type="unfinished"/>
+      <translation> s</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5481"/>
       <source>Tray icon</source>
-      <translation type="unfinished"/>
+      <translation>托盤圖示</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5490"/>
       <source>Minimize to tray</source>
-      <translation type="unfinished"/>
+      <translation>最小化到托盤</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5500"/>
       <source>Close to tray</source>
-      <translation type="unfinished"/>
+      <translation>關閉時隱藏到托盤</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5507"/>
       <source>Enable system tray icon</source>
-      <translation type="unfinished"/>
+      <translation>顯示托盤圖示</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5591"/>
       <source>Use proxy</source>
-      <translation type="unfinished"/>
+      <translation>使用代理</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5636"/>
       <source>HTTP</source>
-      <translation type="unfinished"/>
+      <translation>HTTP</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5641"/>
       <source>SOCKS v5</source>
-      <translation type="unfinished"/>
+      <translation>SOCKS v5</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5649"/>
       <location filename="../gui/src/settings/options-window.ui" line="5897"/>
       <source>Host</source>
-      <translation type="unfinished"/>
+      <translation>主機</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5659"/>
       <source>Port</source>
-      <translation type="unfinished"/>
+      <translation>埠</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5673"/>
       <location filename="../gui/src/settings/options-window.ui" line="5907"/>
       <source>User</source>
-      <translation type="unfinished"/>
+      <translation>使用者名稱</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5680"/>
       <location filename="../gui/src/settings/options-window.ui" line="5917"/>
       <source>Password</source>
-      <translation type="unfinished"/>
+      <translation>密碼</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5700"/>
       <source>Use system-wide proxy settings</source>
-      <translation type="unfinished"/>
+      <translation>使用全局代理設置</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5717"/>
       <source>Add a web service</source>
-      <translation type="unfinished"/>
+      <translation>添加一個網路服務</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5771"/>
       <location filename="../gui/src/settings/options-window.ui" line="5851"/>
       <source>Tag (after)</source>
-      <translation type="unfinished"/>
+      <translation>標籤（之前）</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5741"/>
       <location filename="../gui/src/settings/options-window.ui" line="5831"/>
       <source>Tag (before)</source>
-      <translation type="unfinished"/>
+      <translation>標籤（之後）</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5751"/>
       <location filename="../gui/src/settings/options-window.ui" line="5871"/>
       <source>Additional tags: &lt;i&gt;%tag%&lt;/i&gt;, &lt;i&gt;%type%&lt;/i&gt;, &lt;i&gt;%number%&lt;/i&gt;.&lt;br/&gt;&lt;i&gt;%tag%&lt;/i&gt;: the tag&lt;br/&gt;&lt;i&gt;%type%&lt;/i&gt;: tag type, "general", "artist", "copyright", "character", "model" or "photo_set"&lt;br/&gt;&lt;i&gt;%number%&lt;/i&gt;: the tag type number (between 0 and 6)</source>
-      <translation type="unfinished"/>
+      <translation>額外標籤: &lt;i&gt;%tag%&lt;/i&gt;, &lt;i&gt;%type%&lt;/i&gt;, &lt;i&gt;%number%&lt;/i&gt;.&lt;br/&gt;&lt;i&gt;%tag%&lt;/i&gt;: 標籤本身&lt;br/&gt;&lt;i&gt;%type%&lt;/i&gt;: 標籤類型, "general", "artist", "copyright", "character", "model" 或 "photo_set"&lt;br/&gt;&lt;i&gt;%number%&lt;/i&gt;: 標籤類型數 (介於 0 和 6 之間)</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="1561"/>
@@ -4032,33 +4067,33 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5821"/>
       <source>Start</source>
-      <translation type="unfinished"/>
+      <translation>開始</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5861"/>
       <source>End</source>
-      <translation type="unfinished"/>
+      <translation>結束</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5891"/>
       <source>Credentials</source>
-      <translation type="unfinished"/>
+      <translation>驗證</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.ui" line="5937"/>
       <source>Driver</source>
-      <translation type="unfinished"/>
+      <translation>驅動</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.cpp" line="226"/>
       <source>exiftool not found</source>
-      <translation type="unfinished"/>
+      <translation>找不到 exiftool</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.cpp" line="305"/>
       <location filename="../gui/src/settings/options-window.cpp" line="1329"/>
       <source>Shortcut</source>
-      <translation type="unfinished"/>
+      <translation>快捷鍵</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.cpp" line="305"/>
@@ -4066,33 +4101,33 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/settings/options-window.cpp" line="1329"/>
       <location filename="../gui/src/settings/options-window.cpp" line="1332"/>
       <source>Hard link</source>
-      <translation type="unfinished"/>
+      <translation>硬連結</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.cpp" line="308"/>
       <location filename="../gui/src/settings/options-window.cpp" line="1332"/>
       <source>Symbolic link</source>
-      <translation type="unfinished"/>
+      <translation>符號連結</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.cpp" line="563"/>
       <source>Choose a save folder</source>
-      <translation type="unfinished"/>
+      <translation>選擇保存的文件夾</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.cpp" line="570"/>
       <source>Choose a save folder for favorites</source>
-      <translation type="unfinished"/>
+      <translation>選擇收藏保存的文件夾</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.cpp" line="577"/>
       <source>Choose a temporary folder</source>
-      <translation type="unfinished"/>
+      <translation>選擇臨時文件夾</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.cpp" line="676"/>
       <source>View</source>
-      <translation type="unfinished"/>
+      <translation>查看</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.cpp" line="697"/>
@@ -4102,20 +4137,20 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/settings/options-window.cpp" line="697"/>
       <source>URL</source>
-      <translation type="unfinished"/>
+      <translation>URL</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.cpp" line="734"/>
       <location filename="../gui/src/settings/options-window.cpp" line="846"/>
       <source>Edit</source>
-      <translation type="unfinished"/>
+      <translation>編輯</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.cpp" line="681"/>
       <location filename="../gui/src/settings/options-window.cpp" line="739"/>
       <location filename="../gui/src/settings/options-window.cpp" line="851"/>
       <source>Remove</source>
-      <translation type="unfinished"/>
+      <translation>移除</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.cpp" line="150"/>
@@ -4166,22 +4201,22 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/settings/options-window.cpp" line="1017"/>
       <source>Choose a color</source>
-      <translation type="unfinished"/>
+      <translation>選擇一個顏色</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.cpp" line="1031"/>
       <source>Choose a font</source>
-      <translation type="unfinished"/>
+      <translation>選擇一個字體</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.cpp" line="1306"/>
       <source>An error occured creating the save folder.</source>
-      <translation type="unfinished"/>
+      <translation>創建保存目錄時出錯。</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.cpp" line="1321"/>
       <source>An error occured creating the favorites save folder.</source>
-      <translation type="unfinished"/>
+      <translation>創建收藏保存目錄時出錯。</translation>
     </message>
   </context>
   <context>
@@ -4189,12 +4224,12 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../lib/src/models/page.cpp" line="103"/>
       <source>No valid source of the site returned result.</source>
-      <translation type="unfinished"/>
+      <translation>沒有有效的站點返回數據來源。</translation>
     </message>
     <message>
       <location filename="../lib/src/models/page.cpp" line="137"/>
       <source>No available API to perform the request.</source>
-      <translation type="unfinished"/>
+      <translation>沒有可用於執行請求的 API</translation>
     </message>
   </context>
   <context>
@@ -4202,47 +4237,47 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/tabs/pool-tab.ui" line="116"/>
       <source>Pl&amp;us</source>
-      <translation type="unfinished"/>
+      <translation>+ (&amp;U)</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/pool-tab.ui" line="139"/>
       <source>O&amp;k</source>
-      <translation type="unfinished"/>
+      <translation>確定 (&amp;K)</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/pool-tab.ui" line="179"/>
       <source>Maybe you meant:</source>
-      <translation type="unfinished"/>
+      <translation>你要找的是不是:</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/pool-tab.ui" line="208"/>
       <source>Images per page</source>
-      <translation type="unfinished"/>
+      <translation>每頁圖片數</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/pool-tab.ui" line="228"/>
       <source>Number of columns</source>
-      <translation type="unfinished"/>
+      <translation>列數</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/pool-tab.ui" line="245"/>
       <source>Post-filtering</source>
-      <translation type="unfinished"/>
+      <translation>後過濾</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/pool-tab.ui" line="415"/>
       <source>Get &amp;selected</source>
-      <translation type="unfinished"/>
+      <translation>獲取選中 (&amp;S)</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/pool-tab.ui" line="422"/>
       <source>Get this &amp;page</source>
-      <translation type="unfinished"/>
+      <translation>獲取此頁 (&amp;P)</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/pool-tab.ui" line="429"/>
       <source>Get &amp;all</source>
-      <translation type="unfinished"/>
+      <translation>獲取全部 (&amp;A)</translation>
     </message>
   </context>
   <context>
@@ -4250,98 +4285,98 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../lib/src/filename/filename.cpp" line="303"/>
       <source>Filename must not be empty!</source>
-      <translation type="unfinished"/>
+      <translation>檔案名不能為空！</translation>
     </message>
     <message>
       <location filename="../lib/src/filename/filename.cpp" line="308"/>
       <source>Can't validate Javascript expressions.</source>
-      <translation type="unfinished"/>
+      <translation>無法驗證 Javascript 表達式。</translation>
     </message>
     <message>
       <location filename="../lib/src/filename/filename.cpp" line="314"/>
       <source>Can't compile your filename: %1</source>
-      <translation type="unfinished"/>
+      <translation>無法編譯您的檔案名: %1</translation>
     </message>
     <message>
       <location filename="../lib/src/filename/filename.cpp" line="321"/>
       <source>Your filename doesn't ends by an extension, symbolized by %ext%! You may not be able to open saved files.</source>
-      <translation type="unfinished"/>
+      <translation>你的檔案名不以副檔名結束，請添加 %ext%！否則你可能無法打開保存的文件。</translation>
     </message>
     <message>
       <location filename="../lib/src/filename/filename.cpp" line="326"/>
       <source>Your filename is not unique to each image and an image may overwrite a previous one at saving! You should use%md5%, which is unique to each image, to avoid this inconvenience.</source>
-      <translation type="unfinished"/>
+      <translation>你的檔案名不唯一，新圖片可能會將之前的圖片覆蓋！你應該使用 %md5%，因為它是唯一的，可以避免不便。</translation>
     </message>
     <message>
       <location filename="../lib/src/filename/filename.cpp" line="347"/>
       <source>The %%1% token does not exist and will not be replaced.</source>
-      <translation type="unfinished"/>
+      <translation>%%1% 變數不存在，且不會被替換。</translation>
     </message>
     <message>
       <location filename="../lib/src/filename/filename.cpp" line="356"/>
       <source>Your format contains characters forbidden on Windows! Forbidden characters: * ? " : &lt; &gt; |</source>
-      <translation type="unfinished"/>
+      <translation>你的檔案名格式存在 Windows 不允許的字元！不允許的字元： * ? " : &lt; &gt; |</translation>
     </message>
     <message>
       <location filename="../lib/src/filename/filename.cpp" line="364"/>
       <source>The %num% token does not play well with simultaneous downloads. Consider another method or downloading images one at a time.</source>
-      <translation type="unfinished"/>
+      <translation>%num% 變數和並行下載相容性不佳。請考慮改用其它方法，或一次僅下載一張圖片。</translation>
     </message>
     <message>
       <location filename="../lib/src/filename/filename.cpp" line="370"/>
       <source>You have chosen to use the %id% token. Know that it is only unique for a selected site. The same ID can identify different images depending on the site.</source>
-      <translation type="unfinished"/>
+      <translation>你選擇使用 %id% 變數。它只在特定的站點唯一。相同的 ID 可能在其他站點代表不同的圖片。</translation>
     </message>
     <message>
       <location filename="../lib/src/filename/filename.cpp" line="374"/>
       <source>Valid filename!</source>
-      <translation type="unfinished"/>
+      <translation>檔案名有效！</translation>
     </message>
     <message>
       <location filename="../gui/src/helpers.cpp" line="31"/>
       <source>Error</source>
-      <translation type="unfinished"/>
+      <translation>錯誤</translation>
     </message>
     <message>
       <location filename="../lib/src/models/filtering/token-filter.cpp" line="37"/>
       <source>image has a "%1" token</source>
-      <translation type="unfinished"/>
+      <translation>圖像有一個“%1”標記</translation>
     </message>
     <message>
       <location filename="../lib/src/models/filtering/token-filter.cpp" line="40"/>
       <source>image does not have a "%1" token</source>
-      <translation type="unfinished"/>
+      <translation>圖像沒有“%1”標記</translation>
     </message>
     <message>
       <location filename="../lib/src/models/filtering/meta-filter.cpp" line="179"/>
       <location filename="../lib/src/models/filtering/meta-filter.cpp" line="243"/>
       <location filename="../lib/src/models/filtering/meta-filter.cpp" line="279"/>
       <source>image's %1 does not match</source>
-      <translation type="unfinished"/>
+      <translation>圖片的 %1 不符合</translation>
     </message>
     <message>
       <location filename="../lib/src/models/filtering/meta-filter.cpp" line="182"/>
       <location filename="../lib/src/models/filtering/meta-filter.cpp" line="246"/>
       <location filename="../lib/src/models/filtering/meta-filter.cpp" line="282"/>
       <source>image's %1 match</source>
-      <translation type="unfinished"/>
+      <translation>圖片的 %1 符合</translation>
     </message>
     <message>
       <location filename="../lib/src/models/filtering/meta-filter.cpp" line="158"/>
       <location filename="../lib/src/models/filtering/meta-filter.cpp" line="260"/>
       <source>image is not "%1"</source>
-      <translation type="unfinished"/>
+      <translation>圖片不是 "%1"</translation>
     </message>
     <message>
       <location filename="../lib/src/models/filtering/meta-filter.cpp" line="161"/>
       <location filename="../lib/src/models/filtering/meta-filter.cpp" line="263"/>
       <source>image is "%1"</source>
-      <translation type="unfinished"/>
+      <translation>圖片是 "%1"</translation>
     </message>
     <message>
       <location filename="../lib/src/models/filtering/meta-filter.cpp" line="170"/>
       <source>An image needs a date to be filtered by age</source>
-      <translation type="unfinished"/>
+      <translation>圖像需要一個日期以便按年齡篩選</translation>
     </message>
     <message>
       <location filename="../lib/src/models/filtering/meta-filter.cpp" line="203"/>
@@ -4356,42 +4391,42 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../lib/src/models/filtering/meta-filter.cpp" line="215"/>
       <source>unknown type "%1" (available types: "%2")</source>
-      <translation type="unfinished"/>
+      <translation>未知類型 “%1“ (可用類型: "%2")</translation>
     </message>
     <message>
       <location filename="../lib/src/models/filtering/meta-filter.cpp" line="268"/>
       <source>image's source does not starts with "%1"</source>
-      <translation type="unfinished"/>
+      <translation>圖片的來源不以 "%1" 開頭</translation>
     </message>
     <message>
       <location filename="../lib/src/models/filtering/meta-filter.cpp" line="271"/>
       <source>image's source starts with "%1"</source>
-      <translation type="unfinished"/>
+      <translation>圖片的來源以 "%1" 開頭</translation>
     </message>
     <message>
       <location filename="../lib/src/models/filtering/tag-filter.cpp" line="50"/>
       <source>image does not contains "%1"</source>
-      <translation type="unfinished"/>
+      <translation>圖片不包含 "%1"</translation>
     </message>
     <message>
       <location filename="../lib/src/models/filtering/tag-filter.cpp" line="53"/>
       <source>image contains "%1"</source>
-      <translation type="unfinished"/>
+      <translation>圖片包含 "%1"</translation>
     </message>
     <message>
       <location filename="../gui/src/monitor-table-model.cpp" line="74"/>
       <source>h 'h' m 'm'</source>
-      <translation type="unfinished"/>
+      <translation>h 'h' m 'm'</translation>
     </message>
     <message>
       <location filename="../gui/src/monitor-table-model.cpp" line="74"/>
       <source>h 'h'</source>
-      <translation type="unfinished"/>
+      <translation>h 'h'</translation>
     </message>
     <message>
       <location filename="../gui/src/monitor-table-model.cpp" line="74"/>
       <source>m 'm'</source>
-      <translation type="unfinished"/>
+      <translation>m 'm'</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/options-window.cpp" line="988"/>
@@ -4452,7 +4487,7 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="26"/>
       <source>Details</source>
-      <translation type="unfinished"/>
+      <translation>詳情</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="26"/>
@@ -4462,7 +4497,7 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="27"/>
       <source>Save as...</source>
-      <translation type="unfinished"/>
+      <translation>保存為...</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="27"/>
@@ -4472,7 +4507,7 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="29"/>
       <source>Save</source>
-      <translation type="unfinished"/>
+      <translation>保存</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="29"/>
@@ -4483,32 +4518,32 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="30"/>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="40"/>
       <source>Saving...</source>
-      <translation type="unfinished"/>
+      <translation>保存...</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="31"/>
       <source>Saved!</source>
-      <translation type="unfinished"/>
+      <translation>保存完成！</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="32"/>
       <source>Copied!</source>
-      <translation type="unfinished"/>
+      <translation>已複製！</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="33"/>
       <source>Moved!</source>
-      <translation type="unfinished"/>
+      <translation>已移動！</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="34"/>
       <source>Link created!</source>
-      <translation type="unfinished"/>
+      <translation>連結已創建！</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="35"/>
       <source>MD5 already exists</source>
-      <translation type="unfinished"/>
+      <translation>MD5 已存在</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="36"/>
@@ -4518,7 +4553,7 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="37"/>
       <source>Delete</source>
-      <translation type="unfinished"/>
+      <translation>刪除</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="39"/>
@@ -4533,12 +4568,12 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="41"/>
       <source>Close</source>
-      <translation type="unfinished"/>
+      <translation>關閉</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="43"/>
       <source>Open</source>
-      <translation type="unfinished"/>
+      <translation>打開</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="43"/>
@@ -4548,7 +4583,7 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="45"/>
       <source>Save (fav)</source>
-      <translation type="unfinished"/>
+      <translation>保存 (收藏)</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="45"/>
@@ -4569,22 +4604,22 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="48"/>
       <source>Copied! (fav)</source>
-      <translation type="unfinished"/>
+      <translation>已複製！（收藏）</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="49"/>
       <source>Moved! (fav)</source>
-      <translation type="unfinished"/>
+      <translation>已移動！（收藏）</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="50"/>
       <source>Link created! (fav)</source>
-      <translation type="unfinished"/>
+      <translation>連結已創建! (fav)</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="51"/>
       <source>MD5 already exists (fav)</source>
-      <translation type="unfinished"/>
+      <translation>MD5 已存在 (fav)</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="52"/>
@@ -4594,12 +4629,12 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="53"/>
       <source>Delete (fav)</source>
-      <translation type="unfinished"/>
+      <translation>刪除（收藏）</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="55"/>
       <source>Save &amp; close (fav)</source>
-      <translation type="unfinished"/>
+      <translation>保存並關閉 (收藏)</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="55"/>
@@ -4609,12 +4644,12 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="57"/>
       <source>Close (fav)</source>
-      <translation type="unfinished"/>
+      <translation>關閉（收藏）</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="59"/>
       <source>Open (fav)</source>
-      <translation type="unfinished"/>
+      <translation>打開 (收藏)</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window-buttons.h" line="59"/>
@@ -4633,82 +4668,84 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/utils/rename-existing/rename-existing-1.ui" line="24"/>
       <source>Folder</source>
-      <translation type="unfinished"/>
+      <translation>文件夾</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/rename-existing/rename-existing-1.ui" line="34"/>
       <source>Force md5 calculation</source>
-      <translation type="unfinished"/>
+      <translation>強制進行 md5 計算</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/rename-existing/rename-existing-1.ui" line="41"/>
       <source>Get md5 in filename</source>
-      <translation type="unfinished"/>
+      <translation>通過檔案名獲取 md5</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/rename-existing/rename-existing-1.ui" line="51"/>
       <source>Origin filename</source>
-      <translation type="unfinished"/>
+      <translation>源檔案名</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/rename-existing/rename-existing-1.ui" line="61"/>
       <source>Destination filename</source>
-      <translation type="unfinished"/>
+      <translation>目標檔案名</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/rename-existing/rename-existing-1.ui" line="71"/>
       <source>Source</source>
-      <translation type="unfinished"/>
+      <translation>來源</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/rename-existing/rename-existing-1.ui" line="84"/>
       <source>%v/%m</source>
-      <translation type="unfinished"/>
+      <translation>%v/%m</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/rename-existing/rename-existing-1.ui" line="106"/>
       <source>Continue</source>
-      <translation type="unfinished"/>
+      <translation>繼續</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/rename-existing/rename-existing-1.ui" line="113"/>
       <source>Cancel</source>
-      <translation type="unfinished"/>
+      <translation>取消</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/rename-existing/rename-existing-1.ui" line="125"/>
       <source>Suffixes</source>
-      <translation type="unfinished"/>
+      <translation>後綴</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/rename-existing/rename-existing-1.ui" line="132"/>
       <source>Get ID in filename</source>
-      <translation type="unfinished"/>
+      <translation>通過檔案名獲取 ID</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/rename-existing/rename-existing-1.cpp" line="61"/>
       <source>This folder does not exist.</source>
-      <translation type="unfinished"/>
+      <translation>這個文件夾不存在。</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/rename-existing/rename-existing-1.cpp" line="68"/>
       <source>If you want to get the MD5 from the filename, you have to include the %md5% token in it.</source>
-      <translation type="unfinished"/>
+      <translation>如果你想要從檔案名獲得 MD5，你必須先添加 %md5% 變數到檔案名中。</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/rename-existing/rename-existing-1.cpp" line="73"/>
       <source>If you want to get the ID from the filename, you have to include the %id% token in it.</source>
-      <translation type="unfinished"/>
+      <translation>如果你想要從檔案名獲得 ID，你必須先添加 %id% 變數到檔案名中。</translation>
     </message>
     <message numerus="yes">
       <location filename="../gui/src/utils/rename-existing/rename-existing-1.cpp" line="122"/>
       <source>You are about to download information from %n image(s). Are you sure you want to continue?</source>
-      <translation type="unfinished"/>
+      <translation>
+        <numerusform>你將要下載 %n 張圖片的資訊。你確定要繼續嗎？</numerusform>
+      </translation>
     </message>
     <message>
       <location filename="../gui/src/utils/rename-existing/rename-existing-1.cpp" line="138"/>
       <source>No image found when renaming image '%1'</source>
-      <translation type="unfinished"/>
+      <translation>重命名圖像 '%1' 時未找到圖像</translation>
     </message>
   </context>
   <context>
@@ -4721,17 +4758,17 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/utils/rename-existing/rename-existing-2.ui" line="24"/>
       <source>The following images will be renamed.</source>
-      <translation type="unfinished"/>
+      <translation>下面的圖片將會被重命名。</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/rename-existing/rename-existing-2.ui" line="49"/>
       <source>Ok</source>
-      <translation type="unfinished"/>
+      <translation>確定</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/rename-existing/rename-existing-2.ui" line="56"/>
       <source>Cancel</source>
-      <translation type="unfinished"/>
+      <translation>取消</translation>
     </message>
   </context>
   <context>
@@ -4739,17 +4776,17 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/utils/rename-existing/rename-existing-table-model.cpp" line="29"/>
       <source>Thumbnail</source>
-      <translation type="unfinished"/>
+      <translation>縮圖</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/rename-existing/rename-existing-table-model.cpp" line="30"/>
       <source>Original</source>
-      <translation type="unfinished"/>
+      <translation>源檔案名</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/rename-existing/rename-existing-table-model.cpp" line="31"/>
       <source>Destination</source>
-      <translation type="unfinished"/>
+      <translation>保存目的地</translation>
     </message>
   </context>
   <context>
@@ -4757,57 +4794,57 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/tabs/search-tab.cpp" line="189"/>
       <source>invalid or missing login information</source>
-      <translation type="unfinished"/>
+      <translation>無效或缺少登錄資訊</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/search-tab.cpp" line="195"/>
       <source>all images filtered</source>
-      <translation type="unfinished"/>
+      <translation>所有圖像均被過濾</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/search-tab.cpp" line="201"/>
       <source>server offline</source>
-      <translation type="unfinished"/>
+      <translation>伺服器不在線</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/search-tab.cpp" line="206"/>
       <source>too many tags</source>
-      <translation type="unfinished"/>
+      <translation>標籤過多</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/search-tab.cpp" line="211"/>
       <source>page too far</source>
-      <translation type="unfinished"/>
+      <translation>頁面過多</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/search-tab.cpp" line="418"/>
       <source>HTTPS redirection detected</source>
-      <translation type="unfinished"/>
+      <translation>檢測到 HTTPS 重定向</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/search-tab.cpp" line="419"/>
       <source>An HTTP to HTTPS redirection has been detected for the website %1. Do you want to enable SSL on it? The recommended setting is 'yes'.</source>
-      <translation type="unfinished"/>
+      <translation>網站 %1檢測到 HTTP 至 HTTPS 重定向。您想啟用 SSL 嗎？建議設置為“是”。</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/search-tab.cpp" line="421"/>
       <source>Always</source>
-      <translation type="unfinished"/>
+      <translation>總是</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/search-tab.cpp" line="422"/>
       <source>Never for that website</source>
-      <translation type="unfinished"/>
+      <translation>對此網站禁用</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/search-tab.cpp" line="423"/>
       <source>Never</source>
-      <translation type="unfinished"/>
+      <translation>從不</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/search-tab.cpp" line="587"/>
       <source>Some tags from the image are in the whitelist: %1. However, some tags are in the blacklist: %2. Do you want to download it anyway?</source>
-      <translation type="unfinished"/>
+      <translation>這個圖片中的一些標籤是白名單中的：%1。但是，也有一些標籤是黑名單中的：%2。你依然想要下載嗎？</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/search-tab.cpp" line="759"/>
@@ -4818,44 +4855,46 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/tabs/search-tab.cpp" line="770"/>
       <location filename="../gui/src/tabs/search-tab.cpp" line="818"/>
       <source>Page %1 of %2 (%3 of %4)</source>
-      <translation type="unfinished"/>
+      <translation>第 %1 頁 共 %2 頁 (第 %3 頁 共 %4 頁)</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/search-tab.cpp" line="770"/>
       <location filename="../gui/src/tabs/search-tab.cpp" line="813"/>
       <location filename="../gui/src/tabs/search-tab.cpp" line="816"/>
       <source>max %1</source>
-      <translation type="unfinished"/>
+      <translation>最大 %1</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/search-tab.cpp" line="785"/>
       <source>No result</source>
-      <translation type="unfinished"/>
+      <translation>沒有結果</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/search-tab.cpp" line="786"/>
       <source>Possible reasons: %1</source>
-      <translation type="unfinished"/>
+      <translation>可能的原因：%1</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/search-tab.cpp" line="823"/>
       <source>%1 filtered</source>
-      <translation type="unfinished"/>
+      <translation>%1 已過濾</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/search-tab.cpp" line="872"/>
       <source>Save selected</source>
-      <translation type="unfinished"/>
+      <translation>保存所選</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/search-tab.cpp" line="1095"/>
       <source>Blacklist</source>
-      <translation type="unfinished"/>
+      <translation>黑名單</translation>
     </message>
     <message numerus="yes">
       <location filename="../gui/src/tabs/search-tab.cpp" line="1095"/>
       <source>%n tag figuring in the blacklist detected in this image: %1. Do you want to display it anyway?</source>
-      <translation type="unfinished"/>
+      <translation>
+        <numerusform>%1 這個圖片中的 %n 標籤被檢測到在黑名單中。你依然想要顯示它嗎？</numerusform>
+      </translation>
     </message>
   </context>
   <context>
@@ -4863,72 +4902,72 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/search-window.ui" line="14"/>
       <source>Search</source>
-      <translation type="unfinished"/>
+      <translation>搜索</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="27"/>
       <source>Sort by</source>
-      <translation type="unfinished"/>
+      <translation>篩選</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="40"/>
       <source>ID (ascending)</source>
-      <translation type="unfinished"/>
+      <translation>ID (升序)</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="45"/>
       <source>ID (descending)</source>
-      <translation type="unfinished"/>
+      <translation>ID (降序)</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="50"/>
       <source>Score (ascending)</source>
-      <translation type="unfinished"/>
+      <translation>得分 (升序)</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="55"/>
       <source>Score (descending)</source>
-      <translation type="unfinished"/>
+      <translation>得分 (降序)</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="60"/>
       <source>Megapixels (ascending)</source>
-      <translation type="unfinished"/>
+      <translation>百萬像素 (升序)</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="65"/>
       <source>Megapixels (descending)</source>
-      <translation type="unfinished"/>
+      <translation>百萬像素 (降序)</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="70"/>
       <source>Filesize</source>
-      <translation type="unfinished"/>
+      <translation>檔案大小</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="75"/>
       <source>Landscape orientation</source>
-      <translation type="unfinished"/>
+      <translation>橫向圖片</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="80"/>
       <source>Portrait orientation</source>
-      <translation type="unfinished"/>
+      <translation>縱向圖片</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="85"/>
       <source>Favorites count</source>
-      <translation type="unfinished"/>
+      <translation>收藏數</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="90"/>
       <source>Rank</source>
-      <translation type="unfinished"/>
+      <translation>排名</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="98"/>
       <source>Rating</source>
-      <translation type="unfinished"/>
+      <translation>分級</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="113"/>
@@ -4943,97 +4982,97 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/search-window.ui" line="123"/>
       <source>Safe</source>
-      <translation type="unfinished"/>
+      <translation>安全評級 (Safe)</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="128"/>
       <source>Safe (no)</source>
-      <translation type="unfinished"/>
+      <translation>非安全評級 (Safe no)</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="133"/>
       <source>Questionable</source>
-      <translation type="unfinished"/>
+      <translation>疑問評級 (Questionable)</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="138"/>
       <source>Questionable (no)</source>
-      <translation type="unfinished"/>
+      <translation>非疑問評級 (Questionable no)</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="143"/>
       <source>Explicit</source>
-      <translation type="unfinished"/>
+      <translation>限制級 (Explicit)</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="148"/>
       <source>Explicit (no)</source>
-      <translation type="unfinished"/>
+      <translation>非限制級 (Explicit no)</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="158"/>
       <source>Status</source>
-      <translation type="unfinished"/>
+      <translation>狀態</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="171"/>
       <source>Deleted</source>
-      <translation type="unfinished"/>
+      <translation>已刪除 (Deleted)</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="176"/>
       <source>Active</source>
-      <translation type="unfinished"/>
+      <translation>正常 (Active)</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="181"/>
       <source>Flagged</source>
-      <translation type="unfinished"/>
+      <translation>已被標記 (Flagged)</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="186"/>
       <source>Pending</source>
-      <translation type="unfinished"/>
+      <translation>等待處理 (Pending)</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="191"/>
       <source>All</source>
-      <translation type="unfinished"/>
+      <translation>所有狀態</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="199"/>
       <source>Date</source>
-      <translation type="unfinished"/>
+      <translation>日期</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="211"/>
       <source>Calendar</source>
-      <translation type="unfinished"/>
+      <translation>日曆</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="225"/>
       <source>Remember that some imageboards forbid the usage of more than a certain amount of tags for non-premium members.</source>
-      <translation type="unfinished"/>
+      <translation>請記住，某些貼圖板不支持非高級用戶使用一定數量以上的標籤進行篩選。</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="253"/>
       <source>Image</source>
-      <translation type="unfinished"/>
+      <translation>圖片</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.ui" line="272"/>
       <source>Tags</source>
-      <translation type="unfinished"/>
+      <translation>標籤</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.cpp" line="25"/>
       <source>Choose a date</source>
-      <translation type="unfinished"/>
+      <translation>選擇一個日期</translation>
     </message>
     <message>
       <location filename="../gui/src/search-window.cpp" line="120"/>
       <source>Search an image</source>
-      <translation type="unfinished"/>
+      <translation>以圖搜圖</translation>
     </message>
   </context>
   <context>
@@ -5041,32 +5080,32 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/docks/settings-dock.ui" line="26"/>
       <source>Downloads</source>
-      <translation type="unfinished"/>
+      <translation>下載</translation>
     </message>
     <message>
       <location filename="../gui/src/docks/settings-dock.ui" line="36"/>
       <source>Folder</source>
-      <translation type="unfinished"/>
+      <translation>文件夾</translation>
     </message>
     <message>
       <location filename="../gui/src/docks/settings-dock.ui" line="78"/>
       <source>Name</source>
-      <translation type="unfinished"/>
+      <translation>名稱</translation>
     </message>
     <message>
       <location filename="../gui/src/docks/settings-dock.ui" line="107"/>
       <source>Reset</source>
-      <translation type="unfinished"/>
+      <translation>重設</translation>
     </message>
     <message>
       <location filename="../gui/src/docks/settings-dock.ui" line="114"/>
       <source>Save</source>
-      <translation type="unfinished"/>
+      <translation>保存</translation>
     </message>
     <message>
       <location filename="../gui/src/docks/settings-dock.cpp" line="46"/>
       <source>Choose a save folder</source>
-      <translation type="unfinished"/>
+      <translation>選擇保存文件夾</translation>
     </message>
   </context>
   <context>
@@ -5074,32 +5113,32 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/sources/site-window.ui" line="17"/>
       <source>Add a site</source>
-      <translation type="unfinished"/>
+      <translation>添加一個站點</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/site-window.ui" line="32"/>
       <source>Type</source>
-      <translation type="unfinished"/>
+      <translation>類型</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/site-window.ui" line="44"/>
       <source>Guess</source>
-      <translation type="unfinished"/>
+      <translation>自動猜測</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/site-window.ui" line="53"/>
       <source>Url</source>
-      <translation type="unfinished"/>
+      <translation>Url</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/site-window.ui" line="74"/>
       <source>%v/%m</source>
-      <translation type="unfinished"/>
+      <translation>%v/%m</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/site-window.cpp" line="52"/>
       <source>The url you entered is not valid.</source>
-      <translation type="unfinished"/>
+      <translation>您輸入的 url 無效。</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/site-window.cpp" line="78"/>
@@ -5114,7 +5153,7 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/sources/site-window.cpp" line="124"/>
       <source>Unable to guess site's type. Are you sure about the url?</source>
-      <translation type="unfinished"/>
+      <translation>無法猜測站點類型。你確定這是一個 url 嗎？</translation>
     </message>
   </context>
   <context>
@@ -5127,12 +5166,12 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/settings/source-registry-window.ui" line="33"/>
       <source>Name</source>
-      <translation type="unfinished"/>
+      <translation>名稱</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/source-registry-window.ui" line="53"/>
       <source>URL</source>
-      <translation type="unfinished"/>
+      <translation>URL</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/source-registry-window.ui" line="82"/>
@@ -5142,12 +5181,12 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/settings/source-registry-window.ui" line="111"/>
       <source>Sources</source>
-      <translation type="unfinished"/>
+      <translation>來源</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/source-registry-window.ui" line="144"/>
       <source>Close</source>
-      <translation type="unfinished"/>
+      <translation>關閉</translation>
     </message>
   </context>
   <context>
@@ -5155,88 +5194,88 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="14"/>
       <source>Site options</source>
-      <translation type="unfinished"/>
+      <translation>站點選項</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="28"/>
       <source>General</source>
-      <translation type="unfinished"/>
+      <translation>一般</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="67"/>
       <source>Referer (default)</source>
-      <translation type="unfinished"/>
+      <translation>Referer (默認)</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="75"/>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="111"/>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="147"/>
       <source>None</source>
-      <translation type="unfinished"/>
+      <translation>無</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="80"/>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="116"/>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="152"/>
       <source>Site</source>
-      <translation type="unfinished"/>
+      <translation>站點</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="85"/>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="121"/>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="157"/>
       <source>Page</source>
-      <translation type="unfinished"/>
+      <translation>頁面</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="90"/>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="126"/>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="167"/>
       <source>Image</source>
-      <translation type="unfinished"/>
+      <translation>圖片</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="98"/>
       <source>Referer (preview)</source>
-      <translation type="unfinished"/>
+      <translation>Referer (預覽)</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="106"/>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="142"/>
       <source>Default</source>
-      <translation type="unfinished"/>
+      <translation>默認</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="134"/>
       <source>Referer (image)</source>
-      <translation type="unfinished"/>
+      <translation>Referer (圖片)</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="162"/>
       <source>Details</source>
-      <translation type="unfinished"/>
+      <translation>詳情</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="37"/>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="578"/>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="613"/>
       <source>Name</source>
-      <translation type="unfinished"/>
+      <translation>名稱</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="57"/>
       <source>Ignore (always)</source>
-      <translation type="unfinished"/>
+      <translation>忽略（每一頁）</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="47"/>
       <source>Ignore (page 1)</source>
-      <translation type="unfinished"/>
+      <translation>忽略（僅第一頁）</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="175"/>
       <source>Use a secure connection (https)</source>
-      <translation type="unfinished"/>
+      <translation>使用安全連接（https）</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="192"/>
@@ -5246,37 +5285,37 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="213"/>
       <source>Download</source>
-      <translation type="unfinished"/>
+      <translation>下載</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="219"/>
       <source>Max simultaneous downloads</source>
-      <translation type="unfinished"/>
+      <translation>最大同時下載數</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="236"/>
       <source>Interval (thumbnail)</source>
-      <translation type="unfinished"/>
+      <translation>時間間隔（請求縮圖）</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="253"/>
       <source>Interval (image)</source>
-      <translation type="unfinished"/>
+      <translation>時間間隔（請求圖片）</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="270"/>
       <source>Interval (page)</source>
-      <translation type="unfinished"/>
+      <translation>時間間隔（請求頁面）</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="287"/>
       <source>Interval (details)</source>
-      <translation type="unfinished"/>
+      <translation>時間間隔（請求圖片詳情）</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="304"/>
       <source>Interval (error)</source>
-      <translation type="unfinished"/>
+      <translation>時間間隔（發生錯誤）</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="243"/>
@@ -5285,27 +5324,27 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="294"/>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="311"/>
       <source>s</source>
-      <translation type="unfinished"/>
+      <translation> 秒</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="186"/>
       <source>Search</source>
-      <translation type="unfinished"/>
+      <translation>搜索</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="202"/>
       <source>Removed tags</source>
-      <translation type="unfinished"/>
+      <translation>刪除標籤</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="322"/>
       <source>Sources</source>
-      <translation type="unfinished"/>
+      <translation>來源</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="349"/>
       <source>Source 1</source>
-      <translation type="unfinished"/>
+      <translation>來源 1</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="365"/>
@@ -5313,7 +5352,7 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="443"/>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="482"/>
       <source>XML</source>
-      <translation type="unfinished"/>
+      <translation>XML</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="370"/>
@@ -5321,7 +5360,7 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="448"/>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="487"/>
       <source>JSON</source>
-      <translation type="unfinished"/>
+      <translation>JSON</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="375"/>
@@ -5329,7 +5368,7 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="453"/>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="492"/>
       <source>Regex</source>
-      <translation type="unfinished"/>
+      <translation>正則表達式</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="380"/>
@@ -5337,94 +5376,94 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="458"/>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="497"/>
       <source>RSS</source>
-      <translation type="unfinished"/>
+      <translation>RSS</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="388"/>
       <source>Source 2</source>
-      <translation type="unfinished"/>
+      <translation>來源 2</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="427"/>
       <source>Source 3</source>
-      <translation type="unfinished"/>
+      <translation>來源 3</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="466"/>
       <source>Source 4</source>
-      <translation type="unfinished"/>
+      <translation>來源 4</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="508"/>
       <source>Use default sources</source>
-      <translation type="unfinished"/>
+      <translation>使用默認來源</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.cpp" line="105"/>
       <source>Username</source>
-      <translation type="unfinished"/>
+      <translation>使用者名稱</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.cpp" line="107"/>
       <source>Password</source>
-      <translation type="unfinished"/>
+      <translation>密碼</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="560"/>
       <source>Test</source>
-      <translation type="unfinished"/>
+      <translation>測試</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="519"/>
       <source>Login</source>
-      <translation type="unfinished"/>
+      <translation>登錄</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="525"/>
       <source>Type</source>
-      <translation type="unfinished"/>
+      <translation>類型</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.cpp" line="90"/>
       <source>Through URL</source>
-      <translation type="unfinished"/>
+      <translation>通過 URL</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.cpp" line="91"/>
       <source>HTTP Basic</source>
-      <translation type="unfinished"/>
+      <translation>HTTP 基本驗證</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.cpp" line="92"/>
       <source>GET</source>
-      <translation type="unfinished"/>
+      <translation>GET</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.cpp" line="93"/>
       <source>POST</source>
-      <translation type="unfinished"/>
+      <translation>POST</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.cpp" line="94"/>
       <source>OAuth 1</source>
-      <translation type="unfinished"/>
+      <translation>OAuth 1</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="571"/>
       <source>Cookies</source>
-      <translation type="unfinished"/>
+      <translation>Cookies</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="583"/>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="618"/>
       <source>Value</source>
-      <translation type="unfinished"/>
+      <translation>值</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="591"/>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="626"/>
       <source>Add</source>
-      <translation type="unfinished"/>
+      <translation>添加</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="598"/>
@@ -5434,12 +5473,12 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="606"/>
       <source>Headers</source>
-      <translation type="unfinished"/>
+      <translation>請求頭部</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="651"/>
       <source>Delete</source>
-      <translation type="unfinished"/>
+      <translation>刪除</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="658"/>
@@ -5449,122 +5488,122 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="678"/>
       <source>Cancel</source>
-      <translation type="unfinished"/>
+      <translation>取消</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.ui" line="685"/>
       <source>Confirm</source>
-      <translation type="unfinished"/>
+      <translation>確定</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.cpp" line="95"/>
       <source>OAuth 2 (password)</source>
-      <translation type="unfinished"/>
+      <translation>OAuth 2 (密碼)</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.cpp" line="96"/>
       <source>OAuth 2 (JSON password)</source>
-      <translation type="unfinished"/>
+      <translation>OAuth 2 (JSON 密碼)</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.cpp" line="97"/>
       <source>OAuth 2 (client credentials)</source>
-      <translation type="unfinished"/>
+      <translation>OAuth 2 (用戶端憑據)</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.cpp" line="98"/>
       <source>OAuth 2 (client credentials header)</source>
-      <translation type="unfinished"/>
+      <translation>OAuth 2 (用戶端憑據頭)</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.cpp" line="99"/>
       <source>OAuth 2 (refresh token)</source>
-      <translation type="unfinished"/>
+      <translation>OAuth 2 (刷新令牌)</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.cpp" line="100"/>
       <source>OAuth 2 (authorization code)</source>
-      <translation type="unfinished"/>
+      <translation>OAuth 2 (授權碼)</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.cpp" line="101"/>
       <source>OAuth 2 (PKCE)</source>
-      <translation type="unfinished"/>
+      <translation>OAuth 2 (PKCE)</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.cpp" line="106"/>
       <source>User ID</source>
-      <translation type="unfinished"/>
+      <translation>用戶 ID</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.cpp" line="108"/>
       <source>Salt</source>
-      <translation type="unfinished"/>
+      <translation>鹽值</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.cpp" line="109"/>
       <source>API key</source>
-      <translation type="unfinished"/>
+      <translation>API 金鑰</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.cpp" line="110"/>
       <source>Consumer key</source>
-      <translation type="unfinished"/>
+      <translation>客戶金鑰</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.cpp" line="111"/>
       <source>Consumer secret</source>
-      <translation type="unfinished"/>
+      <translation>客戶密碼</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.cpp" line="112"/>
       <source>Access token</source>
-      <translation type="unfinished"/>
+      <translation>訪問令牌</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.cpp" line="113"/>
       <source>Refresh token</source>
-      <translation type="unfinished"/>
+      <translation>刷新令牌</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.cpp" line="209"/>
       <source>Delete a site</source>
-      <translation type="unfinished"/>
+      <translation>刪除站點</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.cpp" line="209"/>
       <source>Are you sure you want to delete the site %1?</source>
-      <translation type="unfinished"/>
+      <translation>你確定想要刪除站點 %1 嗎？</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.cpp" line="228"/>
       <source>Connection...</source>
-      <translation type="unfinished"/>
+      <translation>連接...</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.cpp" line="241"/>
       <source>Success!</source>
-      <translation type="unfinished"/>
+      <translation>測試成功！</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.cpp" line="245"/>
       <source>Failure</source>
-      <translation type="unfinished"/>
+      <translation>測試失敗</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.cpp" line="249"/>
       <source>Unable to test</source>
-      <translation type="unfinished"/>
+      <translation>無法測試</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.cpp" line="341"/>
       <source>Error</source>
-      <translation type="unfinished"/>
+      <translation>錯誤</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-settings-window.cpp" line="341"/>
       <source>You should at least select one source</source>
-      <translation type="unfinished"/>
+      <translation>您至少應選擇一個源</translation>
     </message>
   </context>
   <context>
@@ -5572,48 +5611,48 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/sources/sources-window.ui" line="23"/>
       <source>Sources</source>
-      <translation type="unfinished"/>
+      <translation>來源</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-window.ui" line="48"/>
       <source>Check all</source>
-      <translation type="unfinished"/>
+      <translation>全選</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-window.ui" line="174"/>
       <source>Add</source>
-      <translation type="unfinished"/>
+      <translation>添加</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-window.cpp" line="243"/>
       <source>Options</source>
-      <translation type="unfinished"/>
+      <translation>選項</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-window.cpp" line="304"/>
       <source>An update for this source is available.</source>
-      <translation type="unfinished"/>
+      <translation>這個來源的設置可更新。</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-window.cpp" line="389"/>
       <source>- No preset selected -</source>
-      <translation type="unfinished"/>
+      <translation>- 沒有選擇預設 -</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-window.cpp" line="401"/>
       <source>Create a new preset</source>
-      <translation type="unfinished"/>
+      <translation>創建新預設</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-window.cpp" line="401"/>
       <location filename="../gui/src/sources/sources-window.cpp" line="428"/>
       <source>Name</source>
-      <translation type="unfinished"/>
+      <translation>名稱</translation>
     </message>
     <message>
       <location filename="../gui/src/sources/sources-window.cpp" line="428"/>
       <source>Edit preset</source>
-      <translation type="unfinished"/>
+      <translation>編輯預設</translation>
     </message>
   </context>
   <context>
@@ -5634,7 +5673,7 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/settings/start-window.ui" line="17"/>
       <source>First launch</source>
-      <translation type="unfinished"/>
+      <translation>第一次啟動</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/start-window.ui" line="23"/>
@@ -5644,47 +5683,47 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/settings/start-window.ui" line="41"/>
       <source>Language</source>
-      <translation type="unfinished"/>
+      <translation>語言</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/start-window.ui" line="48"/>
       <source>Folder</source>
-      <translation type="unfinished"/>
+      <translation>文件夾</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/start-window.ui" line="60"/>
       <source>Browse</source>
-      <translation type="unfinished"/>
+      <translation>瀏覽</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/start-window.ui" line="69"/>
       <source>Format</source>
-      <translation type="unfinished"/>
+      <translation>格式</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/start-window.ui" line="102"/>
       <source>Source</source>
-      <translation type="unfinished"/>
+      <translation>來源</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/start-window.ui" line="122"/>
       <source>If you use Grabber for the first time, it is advised to first read the &lt;a href="{website}/docs/"&gt;getting started&lt;/a&gt; wiki page.</source>
-      <translation type="unfinished"/>
+      <translation>如果你第一次使用 Grabber，推薦您先閱讀 &lt;a href="{website}/docs/"&gt;getting started&lt;/a&gt; wiki 頁。</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/start-window.ui" line="137"/>
       <source>Options</source>
-      <translation type="unfinished"/>
+      <translation>選項</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/start-window.cpp" line="58"/>
       <source>Choose a save folder</source>
-      <translation type="unfinished"/>
+      <translation>選擇保存文件夾</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/start-window.cpp" line="94"/>
       <source>An error occurred creating the save folder.</source>
-      <translation type="unfinished"/>
+      <translation>創建保存目錄時出錯。</translation>
     </message>
   </context>
   <context>
@@ -5692,47 +5731,47 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/tag-context-menu.cpp" line="16"/>
       <source>Remove from favorites</source>
-      <translation type="unfinished"/>
+      <translation>從收藏移除</translation>
     </message>
     <message>
       <location filename="../gui/src/tag-context-menu.cpp" line="18"/>
       <source>Choose as image</source>
-      <translation type="unfinished"/>
+      <translation>設置為圖片</translation>
     </message>
     <message>
       <location filename="../gui/src/tag-context-menu.cpp" line="21"/>
       <source>Add to favorites</source>
-      <translation type="unfinished"/>
+      <translation>添加到收藏</translation>
     </message>
     <message>
       <location filename="../gui/src/tag-context-menu.cpp" line="26"/>
       <source>Don't keep for later</source>
-      <translation type="unfinished"/>
+      <translation>取消稍後再看</translation>
     </message>
     <message>
       <location filename="../gui/src/tag-context-menu.cpp" line="28"/>
       <source>Keep for later</source>
-      <translation type="unfinished"/>
+      <translation>稍後再看</translation>
     </message>
     <message>
       <location filename="../gui/src/tag-context-menu.cpp" line="33"/>
       <source>Don't blacklist</source>
-      <translation type="unfinished"/>
+      <translation>不要應用黑名單</translation>
     </message>
     <message>
       <location filename="../gui/src/tag-context-menu.cpp" line="35"/>
       <source>Blacklist</source>
-      <translation type="unfinished"/>
+      <translation>黑名單</translation>
     </message>
     <message>
       <location filename="../gui/src/tag-context-menu.cpp" line="40"/>
       <source>Don't ignore</source>
-      <translation type="unfinished"/>
+      <translation>取消忽略</translation>
     </message>
     <message>
       <location filename="../gui/src/tag-context-menu.cpp" line="42"/>
       <source>Ignore</source>
-      <translation type="unfinished"/>
+      <translation>忽略</translation>
     </message>
     <message>
       <location filename="../gui/src/tag-context-menu.cpp" line="47"/>
@@ -5747,12 +5786,12 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/tag-context-menu.cpp" line="54"/>
       <source>Copy tag</source>
-      <translation type="unfinished"/>
+      <translation>複製標籤</translation>
     </message>
     <message>
       <location filename="../gui/src/tag-context-menu.cpp" line="56"/>
       <source>Copy all tags</source>
-      <translation type="unfinished"/>
+      <translation>複製所有標籤</translation>
     </message>
     <message>
       <location filename="../gui/src/tag-context-menu.cpp" line="57"/>
@@ -5762,17 +5801,17 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/tag-context-menu.cpp" line="62"/>
       <source>Open in a new tab</source>
-      <translation type="unfinished"/>
+      <translation>在新標籤頁打開</translation>
     </message>
     <message>
       <location filename="../gui/src/tag-context-menu.cpp" line="63"/>
       <source>Open in new a window</source>
-      <translation type="unfinished"/>
+      <translation>在新窗口打開</translation>
     </message>
     <message>
       <location filename="../gui/src/tag-context-menu.cpp" line="65"/>
       <source>Open in browser</source>
-      <translation type="unfinished"/>
+      <translation>在瀏覽器中打開</translation>
     </message>
   </context>
   <context>
@@ -5780,12 +5819,12 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../lib/src/tools/tag-list-loader.cpp" line="71"/>
       <source>Loading tag types...</source>
-      <translation type="unfinished"/>
+      <translation>正在載入標籤類型...</translation>
     </message>
     <message>
       <location filename="../lib/src/tools/tag-list-loader.cpp" line="81"/>
       <source>Error loading tag types.</source>
-      <translation type="unfinished"/>
+      <translation>載入標籤類型時出錯</translation>
     </message>
   </context>
   <context>
@@ -5793,37 +5832,39 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/utils/tag-loader/tag-loader.ui" line="14"/>
       <source>Tag loader</source>
-      <translation type="unfinished"/>
+      <translation>標籤載入器</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/tag-loader/tag-loader.ui" line="87"/>
       <source>Start</source>
-      <translation type="unfinished"/>
+      <translation>開始</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/tag-loader/tag-loader.ui" line="94"/>
       <source>Cancel</source>
-      <translation type="unfinished"/>
+      <translation>取消</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/tag-loader/tag-loader.ui" line="109"/>
       <source>Generate the local tag database for a given source. Afterwards, even if the source's API does not provide tag type information, Grabber can directly check it in its local tag database.</source>
-      <translation type="unfinished"/>
+      <translation>生成給定源的本地標籤資料庫。之後，即使源 API 沒有提供標籤類型資訊，Grabber 也可以在本地標籤資料庫中直接檢查。</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/tag-loader/tag-loader.ui" line="24"/>
       <source>Source</source>
-      <translation type="unfinished"/>
+      <translation>來源</translation>
     </message>
     <message>
       <location filename="../gui/src/utils/tag-loader/tag-loader.cpp" line="91"/>
       <source>Finished</source>
-      <translation type="unfinished"/>
+      <translation>已完成</translation>
     </message>
     <message numerus="yes">
       <location filename="../gui/src/utils/tag-loader/tag-loader.cpp" line="91"/>
       <source>%n tag(s) loaded</source>
-      <translation type="unfinished"/>
+      <translation>
+        <numerusform>已載入 %n 個標籤</numerusform>
+      </translation>
     </message>
   </context>
   <context>
@@ -5831,47 +5872,47 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/tabs/tag-tab.ui" line="106"/>
       <source>Pl&amp;us</source>
-      <translation type="unfinished"/>
+      <translation>+ (&amp;U)</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/tag-tab.ui" line="129"/>
       <source>O&amp;k</source>
-      <translation type="unfinished"/>
+      <translation>確定 (&amp;K)</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/tag-tab.ui" line="169"/>
       <source>Maybe you meant:</source>
-      <translation type="unfinished"/>
+      <translation>你要找的是不是:</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/tag-tab.ui" line="198"/>
       <source>Post-filtering</source>
-      <translation type="unfinished"/>
+      <translation>後過濾</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/tag-tab.ui" line="257"/>
       <source>How many sources should appear per line.</source>
-      <translation type="unfinished"/>
+      <translation>每行應該顯示多少來源。</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/tag-tab.ui" line="260"/>
       <source>Number of columns</source>
-      <translation type="unfinished"/>
+      <translation>列數</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/tag-tab.ui" line="267"/>
       <source>Images per page</source>
-      <translation type="unfinished"/>
+      <translation>每頁圖片數</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/tag-tab.ui" line="354"/>
       <source>Load more results</source>
-      <translation type="unfinished"/>
+      <translation>載入更多結果</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/tag-tab.ui" line="415"/>
       <source>S&amp;ources</source>
-      <translation type="unfinished"/>
+      <translation>來源 (&amp;O)</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/tag-tab.ui" line="422"/>
@@ -5886,42 +5927,42 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/tabs/tag-tab.ui" line="482"/>
       <source>Get &amp;selected</source>
-      <translation type="unfinished"/>
+      <translation>獲取選中 (&amp;S)</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/tag-tab.ui" line="489"/>
       <source>Get this &amp;page</source>
-      <translation type="unfinished"/>
+      <translation>獲取此頁 (&amp;P)</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/tag-tab.ui" line="496"/>
       <source>Get &amp;all</source>
-      <translation type="unfinished"/>
+      <translation>獲取全部 (&amp;a)</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/tag-tab.cpp" line="282"/>
       <source>Monitoring an empty search</source>
-      <translation type="unfinished"/>
+      <translation>正監視一個結果為空的搜索</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/tag-tab.cpp" line="282"/>
       <source>You are about to add a monitor for an empty search, which can lead to a lots of results. Are you sure?</source>
-      <translation type="unfinished"/>
+      <translation>您正要為一個結果為空的搜索添加監視器，該搜索可能會產生大量結果。您確定要這麼做嗎？</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/tag-tab.cpp" line="287"/>
       <source>Monitoring a big search</source>
-      <translation type="unfinished"/>
+      <translation>正監視一個巨型搜索</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/tag-tab.cpp" line="287"/>
       <source>You are about to add a monitor for a search with a lot of results (%1). Are you sure?</source>
-      <translation type="unfinished"/>
+      <translation>您正要為一個有巨量結果 (%1) 的搜索添加監視器。您確定要這麼做嗎？</translation>
     </message>
     <message>
       <location filename="../gui/src/tabs/tag-tab.cpp" line="323"/>
       <source>Search</source>
-      <translation type="unfinished"/>
+      <translation>搜索</translation>
     </message>
   </context>
   <context>
@@ -5929,7 +5970,7 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/docks/tags-dock.ui" line="20"/>
       <source>Downloads</source>
-      <translation type="unfinished"/>
+      <translation>下載</translation>
     </message>
   </context>
   <context>
@@ -5937,49 +5978,49 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/ui/text-edit.cpp" line="180"/>
       <source>Favorites</source>
-      <translation type="unfinished"/>
+      <translation>收藏</translation>
     </message>
     <message>
       <location filename="../gui/src/ui/text-edit.cpp" line="189"/>
       <location filename="../gui/src/ui/text-edit.cpp" line="208"/>
       <source>Remove</source>
-      <translation type="unfinished"/>
+      <translation>移除</translation>
     </message>
     <message>
       <location filename="../gui/src/ui/text-edit.cpp" line="191"/>
       <location filename="../gui/src/ui/text-edit.cpp" line="210"/>
       <source>Add</source>
-      <translation type="unfinished"/>
+      <translation>添加</translation>
     </message>
     <message>
       <location filename="../gui/src/ui/text-edit.cpp" line="199"/>
       <source>Kept for later</source>
-      <translation type="unfinished"/>
+      <translation>稍後再看</translation>
     </message>
     <message>
       <location filename="../gui/src/ui/text-edit.cpp" line="217"/>
       <source>Ratings</source>
-      <translation type="unfinished"/>
+      <translation>評級</translation>
     </message>
     <message>
       <location filename="../gui/src/ui/text-edit.cpp" line="228"/>
       <source>Sortings</source>
-      <translation type="unfinished"/>
+      <translation>篩選</translation>
     </message>
     <message>
       <location filename="../gui/src/ui/text-edit.cpp" line="250"/>
       <source>Copy</source>
-      <translation type="unfinished"/>
+      <translation>複製</translation>
     </message>
     <message>
       <location filename="../gui/src/ui/text-edit.cpp" line="251"/>
       <source>Cut</source>
-      <translation type="unfinished"/>
+      <translation>剪切</translation>
     </message>
     <message>
       <location filename="../gui/src/ui/text-edit.cpp" line="253"/>
       <source>Paste</source>
-      <translation type="unfinished"/>
+      <translation>黏貼</translation>
     </message>
   </context>
   <context>
@@ -5995,62 +6036,62 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/settings/token-settings-widget.ui" line="20"/>
       <source>If empty</source>
-      <translation type="unfinished"/>
+      <translation>如果為空</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/token-settings-widget.ui" line="34"/>
       <source>Separator</source>
-      <translation type="unfinished"/>
+      <translation>分割器</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/token-settings-widget.ui" line="48"/>
       <source>Sort</source>
-      <translation type="unfinished"/>
+      <translation>排序</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/token-settings-widget.ui" line="56"/>
       <source>Original</source>
-      <translation type="unfinished"/>
+      <translation>源檔案名</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/token-settings-widget.ui" line="61"/>
       <source>Name</source>
-      <translation type="unfinished"/>
+      <translation>名稱</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/token-settings-widget.ui" line="69"/>
       <source>If more than n tags</source>
-      <translation type="unfinished"/>
+      <translation>如果多餘 n 個標籤</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/token-settings-widget.ui" line="86"/>
       <source>Keep all tags</source>
-      <translation type="unfinished"/>
+      <translation>保留所有標籤</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/token-settings-widget.ui" line="93"/>
       <source>Keep n tags</source>
-      <translation type="unfinished"/>
+      <translation>保留 n 個標籤</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/token-settings-widget.ui" line="103"/>
       <source>Keep n tags, then add</source>
-      <translation type="unfinished"/>
+      <translation>保留 n 個標籤，然後添加</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/token-settings-widget.ui" line="124"/>
       <source>Replace all tags by</source>
-      <translation type="unfinished"/>
+      <translation>用 ... 替換所有標籤</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/token-settings-widget.ui" line="141"/>
       <source>One file per tag</source>
-      <translation type="unfinished"/>
+      <translation>每個標籤只保存一個文件</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/token-settings-widget.ui" line="148"/>
       <source>Use shortest if possible</source>
-      <translation type="unfinished"/>
+      <translation>盡量縮短</translation>
     </message>
   </context>
   <context>
@@ -6058,22 +6099,22 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/updater/update-dialog.ui" line="14"/>
       <source>Updater</source>
-      <translation type="unfinished"/>
+      <translation>更新檢查器</translation>
     </message>
     <message>
       <location filename="../gui/src/updater/update-dialog.ui" line="33"/>
       <source>A new version is available.&lt;br/&gt;Do you want to update now?</source>
-      <translation type="unfinished"/>
+      <translation>新版本可用&lt;br/&gt;你想要現在升級嗎？</translation>
     </message>
     <message>
       <location filename="../gui/src/updater/update-dialog.ui" line="53"/>
       <source>See changelog</source>
-      <translation type="unfinished"/>
+      <translation>查看更新日誌</translation>
     </message>
     <message>
       <location filename="../gui/src/updater/update-dialog.cpp" line="60"/>
       <source>Version &lt;b&gt;%1&lt;/b&gt;</source>
-      <translation type="unfinished"/>
+      <translation>版本 &lt;b&gt;%1&lt;/b&gt;</translation>
     </message>
   </context>
   <context>
@@ -6082,54 +6123,56 @@ Please solve the issue before resuming the download.</source>
       <location filename="../gui/src/viewer/viewer-window.ui" line="23"/>
       <location filename="../gui/src/viewer/viewer-window.cpp" line="1363"/>
       <source>Image</source>
-      <translation type="unfinished"/>
+      <translation>圖片</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window.ui" line="152"/>
       <source>Expand button drawer</source>
-      <translation type="unfinished"/>
+      <translation>展開按鈕抽屜</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window.cpp" line="443"/>
       <source>Reload</source>
-      <translation type="unfinished"/>
+      <translation>刷新</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window.cpp" line="447"/>
       <source>Copy file</source>
-      <translation type="unfinished"/>
+      <translation>複製文件</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window.cpp" line="449"/>
       <source>Copy data</source>
-      <translation type="unfinished"/>
+      <translation>複製數據</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window.cpp" line="451"/>
       <source>Copy link</source>
-      <translation type="unfinished"/>
+      <translation>複製連結</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window.cpp" line="538"/>
       <source>Folder does not exist</source>
-      <translation type="unfinished"/>
+      <translation>文件夾不存在</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window.cpp" line="538"/>
       <source>The save folder does not exist yet. Create it?</source>
-      <translation type="unfinished"/>
+      <translation>保存文件夾不存在。創建一個嗎？</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window.cpp" line="542"/>
       <source>Error creating folder.
 %1</source>
-      <translation type="unfinished"/>
+      <translation>創建文件夾時出錯
+%1</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window.cpp" line="794"/>
       <source>File is too big to be displayed.
 %1</source>
-      <translation type="unfinished"/>
+      <translation>以下文件過大無法顯示
+%1</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window.cpp" line="797"/>
@@ -6149,7 +6192,7 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/viewer/viewer-window.cpp" line="799"/>
       <source>Error loading the image.</source>
-      <translation type="unfinished"/>
+      <translation>載入圖片失敗。</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window.cpp" line="801"/>
@@ -6159,33 +6202,33 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/viewer/viewer-window.cpp" line="803"/>
       <source>Error saving the image.</source>
-      <translation type="unfinished"/>
+      <translation>保存圖像時失敗。</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window.cpp" line="1008"/>
       <location filename="../gui/src/viewer/viewer-window.cpp" line="1010"/>
       <source>Error</source>
-      <translation type="unfinished"/>
+      <translation>錯誤</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window.cpp" line="1008"/>
       <source>You did not specified a save folder! Do you want to open the options window?</source>
-      <translation type="unfinished"/>
+      <translation>你沒有指定保存文件夾！你想要現在打開設置窗口嗎？</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window.cpp" line="1010"/>
       <source>You did not specified a save format! Do you want to open the options window?</source>
-      <translation type="unfinished"/>
+      <translation>你沒有指定保存格式！你想要現在打開設置窗口嗎？</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window.cpp" line="1072"/>
       <source>Error saving image.</source>
-      <translation type="unfinished"/>
+      <translation>保存圖片時發生錯誤。</translation>
     </message>
     <message>
       <location filename="../gui/src/viewer/viewer-window.cpp" line="1095"/>
       <source>Save image</source>
-      <translation type="unfinished"/>
+      <translation>保存圖片</translation>
     </message>
   </context>
   <context>
@@ -6198,12 +6241,12 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/settings/web-service-window.ui" line="20"/>
       <source>Name</source>
-      <translation type="unfinished"/>
+      <translation>名稱</translation>
     </message>
     <message>
       <location filename="../gui/src/settings/web-service-window.ui" line="30"/>
       <source>Url</source>
-      <translation type="unfinished"/>
+      <translation>Url</translation>
     </message>
   </context>
   <context>
@@ -6224,7 +6267,7 @@ Please solve the issue before resuming the download.</source>
     <message>
       <location filename="../gui/src/docks/wiki-dock.ui" line="26"/>
       <source>Downloads</source>
-      <translation type="unfinished"/>
+      <translation>下載</translation>
     </message>
   </context>
 </TS>


### PR DESCRIPTION
## What's this PR for
This PR aims to convert the existing Simplified Chinese translation to Traditional Chinese and place it in the corresponding directories so that the application can display Traditional Chinese UI strings.

## Changes
I have overwritten the following files, all converted from ChineseSimplified.ts to Traditional Chinese using https://zhconvert.org/:
- src/languages/ChineseTraditional.ts
- src/gui-qml/languages/ChineseTraditional.ts
- src/crash-reporter/languages/ChineseTraditional.ts

If there are any issues, please let me know. Thank you!