### PR TITLE
FurAffinity search improvement - return all results

### DIFF
--- a/src/sites/FurAffinity/model.ts
+++ b/src/sites/FurAffinity/model.ts
@@ -23,7 +23,7 @@ export const source: ISource = {
                     if (query.search.length === 0) {
                         return "/browse/?order-by=date&page=" + query.page + "&perpage=" + perpage;
                     }
-                    return "/search/?q=" + encodeURIComponent(query.search) + "&order-by=date&page=" + query.page + "&perpage=" + perpage;
+                    return "/search/?q=" + encodeURIComponent(query.search) + "&order-by=date&range=all&page=" + query.page + "&perpage=" + perpage;
                 },
                 parse: (src: string, statusCode: number): IParsedSearch | IError => {
                     return {


### PR DESCRIPTION
This change simply updates the furaffinity search query to add a &range=all query parameter. 
By default, if no range is provided, only 5 years worth of results are returned. With this parameter added, searches will return results from all time.