### PR TITLE
Add support for "contributor" tag on e621 (fix #3522)

### DIFF
--- a/src/gui/src/settings/options-window.cpp
+++ b/src/gui/src/settings/options-window.cpp
@@ -351,6 +351,7 @@ OptionsWindow::OptionsWindow(Profile *profile, ThemeLoader *themeLoader, QWidget
 		auto *tagsTree = ui->treeWidget->invisibleRootItem()->child(2)->child(5);
 		tagsTree->addChild(new QTreeWidgetItem({ "General" }, tagsTree->type()));
 		tagsTree->addChild(new QTreeWidgetItem({ "Artist" }, tagsTree->type()));
+		tagsTree->addChild(new QTreeWidgetItem({ "Contributor" }, tagsTree->type()));
 		tagsTree->addChild(new QTreeWidgetItem({ "Copyright" }, tagsTree->type()));
 		tagsTree->addChild(new QTreeWidgetItem({ "Character" }, tagsTree->type()));
 		tagsTree->addChild(new QTreeWidgetItem({ "Model" }, tagsTree->type()));
@@ -360,6 +361,7 @@ OptionsWindow::OptionsWindow(Profile *profile, ThemeLoader *themeLoader, QWidget
 		tagsTree->addChild(new QTreeWidgetItem({ "Lore" }, tagsTree->type()));
 		m_tokenSettings.append(new TokenSettingsWidget(settings, "general", false, "", "", " ", this));
 		m_tokenSettings.append(new TokenSettingsWidget(settings, "artist", false, "anonymous", "multiple artists", "+", this));
+		m_tokenSettings.append(new TokenSettingsWidget(settings, "contributor", false, "none", "multiple", "+", this));
 		m_tokenSettings.append(new TokenSettingsWidget(settings, "copyright", true, "misc", "crossover", "+", this));
 		m_tokenSettings.append(new TokenSettingsWidget(settings, "character", false, "unknown", "group", "+", this));
 		m_tokenSettings.append(new TokenSettingsWidget(settings, "model", false, "unknown", "multiple", "+", this));

--- a/src/lib/src/filename/filename.cpp
+++ b/src/lib/src/filename/filename.cpp
@@ -327,7 +327,7 @@ bool Filename::isValid(Profile *profile, QString *error) const
 	}
 
 	// Looking for unknown tokens
-	QStringList knownTokens {"tags", "artist", "general", "copyright", "character", "model", "photo_set", "species", "lore", "meta", "filename", "rating", "md5", "website", "websitename", "ext", "all", "id", "search", "search_(\\d+)", "allo", "date", "score", "count", "width", "height", "pool", "url_file", "url_page", "num", "name", "position", "current_date", "author", "authorid", "parentid", "grabber", "grabber_branch", "grabber_version" };
+	QStringList knownTokens {"tags", "artist", "contributor", "general", "copyright", "character", "model", "photo_set", "species", "lore", "meta", "filename", "rating", "md5", "website", "websitename", "ext", "all", "id", "search", "search_(\\d+)", "allo", "date", "score", "count", "width", "height", "pool", "url_file", "url_page", "num", "name", "position", "current_date", "author", "authorid", "parentid", "grabber", "grabber_branch", "grabber_version" };
 	if (profile != nullptr) {
 		knownTokens.append(profile->getAdditionalTokens());
 		knownTokens.append(getCustoms(profile->getSettings()).keys());
@@ -429,7 +429,7 @@ int Filename::needExactTags(const QStringList &forcedTokens, const QStringList &
 	// Some sources require loading to get the tag list
 	if (forcedTokens.contains("tags")) {
 		// The filename use tags
-		static const QStringList forbidden { "tags", "all", "allo", "artist", "copyright", "character", "model", "photo_set", "species", "lore", "meta", "general" };
+		static const QStringList forbidden { "tags", "all", "allo", "artist", "contributor", "copyright", "character", "model", "photo_set", "species", "lore", "meta", "general" };
 		for (const QString &token : forbidden) {
 			if (toks.contains(token)) {
 				return 2;
@@ -445,7 +445,7 @@ int Filename::needExactTags(const QStringList &forcedTokens, const QStringList &
 	}
 
 	// The filename contains one of the special tags
-	static const QStringList forbidden { "artist", "copyright", "character", "model", "photo_set", "species", "lore", "meta", "general" };
+	static const QStringList forbidden { "artist", "contributor", "copyright", "character", "model", "photo_set", "species", "lore", "meta", "general" };
 	for (const QString &token : forbidden) {
 		if (toks.contains(token)) {
 			return 1;

--- a/src/lib/src/models/image.cpp
+++ b/src/lib/src/models/image.cpp
@@ -1316,6 +1316,7 @@ QMap<QString, Token> Image::generateTokens(Profile *profile) const
 	// Tags
 	tokens.insert("general", Token(details["general"], "keepAll", "", ""));
 	tokens.insert("artist", Token(details["artist"], "keepAll", "anonymous", "multiple artists"));
+	tokens.insert("contributor", Token(details["contributor"], "keepAll", "none", "multiple"));
 	tokens.insert("copyright", Token(details["copyright"], "keepAll", "misc", "crossover"));
 	tokens.insert("character", Token(details["character"], "keepAll", "unknown", "group"));
 	tokens.insert("model", Token(details["model"] + details["idol"], "keepAll", "unknown", "multiple"));

--- a/src/lib/src/tags/tag.cpp
+++ b/src/lib/src/tags/tag.cpp
@@ -183,6 +183,7 @@ bool sortTagsByType(const Tag &s1, const Tag &s2)
 		<< QStringLiteral("lore")
 		<< QStringLiteral("species")
 		<< QStringLiteral("artist")
+		<< QStringLiteral("contributor")
 		<< QStringLiteral("character")
 		<< QStringLiteral("copyright");
 

--- a/src/sites/E621/e621.net/tag-types.txt
+++ b/src/sites/E621/e621.net/tag-types.txt
@@ -1,5 +1,6 @@
 0,general
 1,artist
+2,contributor
 3,copyright
 4,character
 5,species


### PR DESCRIPTION
Adds support for e621's "contributor" tag category, allowing it to be used and customised like other tag categories.
Resolves #3522.