### PR TITLE
Update Sankaku API to V2

### DIFF
--- a/src/sites/Sankaku/chan.sankakucomplex.com/defaults.ini
+++ b/src/sites/Sankaku/chan.sankakucomplex.com/defaults.ini
@@ -1,12 +1,16 @@
 [General]
 referer=page
-referer_preview=page
+referer_preview=host
 referer_image=none
 name=chan.sankakucomplex.com
 ssl=true
 
 [download]
 throttle_retry=120
+
+[sources]
+usedefault=false
+source_1=json
 
 [login]
 type=url

--- a/src/sites/Sankaku/idol.sankakucomplex.com/defaults.ini
+++ b/src/sites/Sankaku/idol.sankakucomplex.com/defaults.ini
@@ -1,6 +1,6 @@
 [General]
 referer=page
-referer_preview=page
+referer_preview=host
 referer_image=none
 name=idol.sankakucomplex.com
 ssl=true
@@ -10,10 +10,7 @@ throttle_retry=120
 
 [sources]
 usedefault=false
-source_1=regex
-source_2=
-source_3=
-source_4=
+source_1=json
 
 [login]
 type=url

--- a/src/sites/Sankaku/model.ts
+++ b/src/sites/Sankaku/model.ts
@@ -1,37 +1,90 @@
 function buildSearch(search: string): string {
     // Replace "ratio:4:3" meta by "4:3_aspect_ratio" tag
-    search = search.replace(/(^| )ratio:(\d+:\d+)($| )/g, "$1$2_aspect_ratio$3");
-
-    return search;
+    return search.replace(/(^| )ratio:(\d+:\d+)($| )/g, "$1$2_aspect_ratio$3");
 }
 
-function buildImageFromJson(img: any): IImage {
-    img.created_at = img.created_at["s"];
-    img.score = img.total_score;
+// Module-level storage for query parameters to enable keyset pagination
+let lastSearchParams = "";
 
-    // Not set for anonymous uploads / deleted users
-    if (img.author) {
+function buildImageFromJson(img: any): IImage {
+    // Date conversion
+    if (img.created_at && typeof img.created_at === "object" && typeof img.created_at.s === "string") {
+        img.created_at = img.created_at.s;
+    }
+
+    // Score and author
+    if (img.total_score !== undefined) {
+        img.score = img.total_score;
+    }
+    if (img.author && img.author.name) {
         img.author = img.author.name;
     }
 
-    return completeImage(img, true);
+    // Video metadata (keep as extra filename token)
+    if (img.video_duration !== undefined) {
+        img.tokens = { ...(img.tokens ?? {}), duration: img.video_duration };
+    }
+
+    // File metadata
+    if (img.file_ext) {
+        img.ext = img.file_ext;
+    }
+
+    return completeImage(img as IImage, true);
 }
 
 function completeImage(img: IImage, fromJson: boolean): IImage {
     if ((!img.file_url || img.file_url.length < 5) && img.preview_url) {
         img.file_url = img.preview_url.replace("/preview/", "/");
     }
-
     if (img.file_url && !fromJson) {
         img.file_url = img.file_url.replace(/([^s])\.sankakucomplex/, "$1s.sankakucomplex");
     }
-
     return img;
+}
+
+const tagTypeById: Record<number, string> = {
+    0: "general",
+    1: "artist",
+    2: "studio",
+    3: "copyright",
+    4: "character",
+    5: "species",
+    8: "medium",
+    9: "meta",
+};
+
+function applyTagTypes(tags: ITag[]): ITag[] {
+    for (const tag of tags) {
+        const rawTypeId = (tag as any).typeId;
+        const typeId = typeof rawTypeId === "string" ? parseInt(rawTypeId, 10) : rawTypeId;
+        if (typeof typeId === "number") {
+            tag.type = tagTypeById[typeId] ?? "unknown";
+        } else {
+            tag.type = "unknown";
+        }
+    }
+    return tags;
 }
 
 export const source: ISource = {
     name: "Sankaku",
-    modifiers: ["rating:safe", "rating:questionable", "rating:explicit", "user:", "fav:", "fastfav:", "md5:", "source:", "id:", "width:", "height:", "score:", "mpixels:", "filesize:", "date:", "gentags:", "arttags:", "chartags:", "copytags:", "approver:", "parent:", "sub:", "order:id", "order:id_desc", "order:score", "order:score_asc", "order:mpixels", "order:mpixels_asc", "order:filesize", "order:landscape", "order:portrait", "order:favcount", "order:rank", "order:change", "order:change_desc", "parent:none", "unlocked:rating"],
+    modifiers: [
+        "rating:safe", "rating:questionable", "rating:explicit",
+        "user:", "fav:", "fastfav:", "md5:", "source:", "id:",
+        "width:", "height:", "score:", "mpixels:", "filesize:", "date:",
+        "gentags:", "arttags:", "chartags:", "copytags:", "approver:",
+        "parent:", "sub:",
+        "order:id", "order:id_desc",
+        "order:score", "order:score_asc",
+        "order:popularity", "order:quality",
+        "order:mpixels", "order:mpixels_asc",
+        "order:filesize",
+        "order:landscape", "order:portrait",
+        "order:favcount", "order:rank",
+        "order:change", "order:change_desc",
+        "parent:none", "unlocked:rating", "threshold:",
+    ],
     tagFormat: {
         case: "lower",
         wordSeparator: "_",
@@ -85,15 +138,37 @@ export const source: ISource = {
         json: {
             name: "JSON",
             auth: [],
-            maxLimit: 200,
+            maxLimit: 100,
             search: {
                 url: (query: ISearchQuery, opts: IUrlOptions, previous: IPreviousSearch | undefined): IRequest => {
-                    const baseUrl = opts.baseUrl
-                        .replace("//chan.", "//capi-v2.")
-                        .replace("//idol.", "//iapi.");
-                    const pagePart = Grabber.pageUrl(query.page, previous, opts.loggedIn ? 1000 : 50, "page={page}", "prev={max}", "next={min-1}");
+                    const isIdol = opts.baseUrl.indexOf("idol") !== -1;
+                    const baseUrl = isIdol ? "https://i.sankakuapi.com" : "https://sankakuapi.com";
                     const search = buildSearch(query.search);
-                    const url = baseUrl + "/posts?lang=en&" + pagePart + "&limit=" + opts.limit + "&tags=" + encodeURIComponent(search);
+                    
+                    // Build query parameters and store for pagination
+                    const queryParams = "lang=en&hide_posts_in_books=in-larger-tags&limit=" + opts.limit + "&tags=" + encodeURIComponent(search);
+                    lastSearchParams = queryParams;
+                    
+                    // Build URL with keyset pagination support
+                    let url = baseUrl + "/v2/posts/keyset?" + queryParams;
+                    
+                    // Append cursor from previous page if navigating
+                    if (previous && (previous as any).urls) {
+                        const prevUrls = (previous as any).urls;
+                        
+                        if (query.page > previous.page && prevUrls.next) {
+                            const match = prevUrls.next.match(/[&?]next=([^&]+)/);
+                            if (match) {
+                                url += "&next=" + match[1];
+                            }
+                        } else if (query.page < previous.page && prevUrls.prev) {
+                            const match = prevUrls.prev.match(/[&?]prev=([^&]+)/);
+                            if (match) {
+                                url += "&prev=" + match[1];
+                            }
+                        }
+                    }
+                    
                     return {
                         url,
                         headers: {
@@ -101,102 +176,51 @@ export const source: ISource = {
                         },
                     };
                 },
-                parse: (src: string): IParsedSearch => {
+                parse: (src: string, _statusCode: number): IParsedSearch => {
                     const data = JSON.parse(src);
-                    const images: IImage[] = data.map(buildImageFromJson);
-                    return { images };
+                    const meta = data.meta || {};
+                    const posts: any[] = Array.isArray(data) ? data : (data.data || data.posts || []);
+
+                    const images: IImage[] = [];
+                    for (const post of posts) {
+                        try {
+                            const image = buildImageFromJson(post);
+                            images.push(image);
+                        } catch {
+                            // Skip invalid posts
+                        }
+                    }
+
+                    const tags = Grabber.regexToTags('"type":(?<typeId>\\d+).*?"(?:name_en|tagName|name)":"(?<name>[^"]+)".*?"(?:post_)?count":(?<count>\\d+)', src) as ITag[];
+                    applyTagTypes(tags);
+                    
+                    // Build pagination URLs with keyset cursors
+                    const result: any = {
+                        images,
+                        tags,
+                    };
+                    
+                    const baseUrl = "https://sankakuapi.com";
+                    if (meta.next) {
+                        result.urlNextPage = baseUrl + "/v2/posts/keyset?" + lastSearchParams + "&next=" + encodeURIComponent(meta.next);
+                    }
+                    if (meta.prev) {
+                        result.urlPrevPage = baseUrl + "/v2/posts/keyset?" + lastSearchParams + "&prev=" + encodeURIComponent(meta.prev);
+                    }
+                    
+                    return result;
                 },
             },
             details: {
-                fullResults: true,
-                url: (id: string, md5: string, opts: IUrlDetailsOptions): string => {
-                    const baseUrl = opts.baseUrl
-                        .replace("//chan.", "//capi-v2.")
-                        .replace("//idol.", "//iapi.");
-                    return baseUrl + "/posts/" + id;
+                url: (id: string, _md5: string, opts: IUrlDetailsOptions): string => {
+                    const isIdol = opts.baseUrl.indexOf("idol") !== -1;
+                    const baseUrl = isIdol ? "https://i.sankakuapi.com" : "https://sankakuapi.com";
+                    return baseUrl + "/v2/posts/" + id;
                 },
-                parse: (src: string): IImage => {
-                    const data = JSON.parse(src);
-                    return buildImageFromJson(data);
-                },
-            }
-        },
-        html: {
-            name: "Regex",
-            auth: [],
-            forcedLimit: 20,
-            forcedTokens: ["*"],
-            search: {
-                url: (query: ISearchQuery, opts: IUrlOptions, previous: IPreviousSearch | undefined): string | IError => {
-                    try {
-                        const pagePart = Grabber.pageUrl(query.page, previous, opts.loggedIn ? 50 : 25, "page={page}", "prev={max}", "next={min-1}");
-                        const search = buildSearch(query.search);
-                        return "/post/index?" + pagePart + "&tags=" + encodeURIComponent(search);
-                    } catch (e: any) {
-                        return { error: e.message };
-                    }
-                },
-                parse: (src: string): IParsedSearch => {
-                    src = src.replace(/<div class="?popular-preview-post"?>[\s\S]+?<\/div>/g, "");
-                    const searchImageCounts = Grabber.regexMatches('class="?tag-(?:count|type-none)"? title="Post Count: (?<count>[0-9,]+)"', src);
-                    const lastPage = Grabber.regexToConst("page", '<span class="?current"?>\\s*(?<page>[0-9,]+)\\s*</span>\\s*>>\\s*</div>', src);
-                    let wiki = Grabber.regexToConst("wiki", '<div id="?wiki-excerpt"?[^>]*>(?<wiki>.+?)</div>', src);
-                    wiki = wiki ? wiki.replace(/href="\/wiki\/show\?title=([^"]+)"/g, 'href="$1"') : undefined;
-                    return {
-                        tags: Grabber.regexToTags('<li class="?[^">]*tag-type-(?<type>[^">]+)(?:|"[^>]*)>.*?<a href="[^"]+"[^>]*>(?<name>[^<]+)</a>.*?<span class="?post-count"?>(?<count>\\d+)</span>.*?</li>', src),
-                        images: Grabber.regexToImages('<span[^>]* id="?p(?<id>\\d+)"?><a[^>]*><img[^>]* src="(?<preview_url>[^"]+/preview/\\w{2}/\\w{2}/(?<md5>[^.]+)\\.[^"]+|[^"]+/download-preview.png)" title="(?<tags>[^"]+)"[^>]+></a></span>', src).map((img: IImage) => completeImage(img, false)),
-                        wiki,
-                        pageCount: lastPage ? Grabber.countToInt(lastPage) : undefined,
-                        imageCount: searchImageCounts.length === 1 ? Grabber.countToInt(searchImageCounts[0].count) : undefined,
-                    };
-                },
-            },
-            details: {
-                url: (id: string, md5: string): string => {
-                    return "/post/show/" + id;
-                },
-                parse: (src: string): IParsedDetails => {
-                    return {
-                        pools: Grabber.regexToPools('<div class="status-notice" id="pool\\d+">[^<]*Pool:[^<]*(?:<a href="/post/show/(?<previous>\\d+)" >&lt;&lt;</a>)?[^<]*<a href="/pool/show/(?<id>\\d+)" >(?<name>[^<]+)</a>[^<]*(?:<a href="/post/show/(?<next>\\d+)" >&gt;&gt;</a>)?[^<]*</div>', src),
-                        tags: Grabber.regexToTags('<li class="?[^">]*tag-type-(?<type>[^">]+)(?:|"[^>]*)>.*?<a href="[^"]+"[^>]*>(?<name>[^<]+)</a>.*?<span class="?post-count"?>(?<count>\\d+)</span>.*?</li>', src),
-                        imageUrl: Grabber.regexToConst("url", '<li>Original: <a href="(?<url>[^"]+)"|<a href="(?<url_2>[^"]+)">Save this file', src).replace(/&amp;/g, "&"),
-                        createdAt: Grabber.regexToConst("date", '<a href="/\\?tags=date[^"]+" title="(?<date>[^"]+)">', src),
-                    };
-                },
-            },
-            tagTypes: {
-                url: (): string => {
-                    return "/tag/index";
-                },
-                parse: (src: string): IParsedTagTypes | IError => {
-                    const contents = src.match(/<select[^>]* id=['"]?type['"]?[^>]*>([\s\S]+)<\/select>/);
-                    if (!contents) {
-                        return { error: "Parse error: could not find the tag type <select> tag" };
-                    }
-                    const results = Grabber.regexMatches('<option value="?(?<id>\\d+)"?>(?<name>[^<]+)</option>', contents[1]);
-                    const types = results.map((r: any) => ({
-                        id: r.id,
-                        name: r.name.toLowerCase(),
-                    }));
-                    return { types };
-                },
-            },
-            tags: {
-                url: (query: ITagsQuery, opts: IUrlOptions): string => {
-                    return "/tag/index?language=en&order=" + query.order + "&page=" + query.page;
-                },
-                parse: (src: string): IParsedTags => {
-                    return {
-                        tags: Grabber.regexToTags('<tr[^>]*>\\s*<td[^>]*>(?<count>\\d+)</td>\\s*<td class="?tag-type-(?<type>[^">]+)"?>\\s*\\[<a[^>]+>\\?</a>\\]\\s*<a[^>]+>(?<name>.+?)</a>\\s*</td>', src),
-                    };
-                },
-            },
-            check: {
-                url: (): string => {
-                    return "/";
-                },
-                parse: (src: string): boolean => {
-                    return src.indexOf("Sankaku") !== -1;
+                parse: (src: string, _statusCode: number): IParsedDetails => {
+                    const tags = Grabber.regexToTags('"type":(?<typeId>.*?),.*?"count":(?<count>.*?),.*?"name":"(?<name>.*?)"}', src) as ITag[];
+                    applyTagTypes(tags);
+                    return { tags };
                 },
             },
         },


### PR DESCRIPTION
- Migrate from page-based to keyset cursor pagination
- Update API endpoint from v1 to `v2/posts/keyset`
- Update referer settings for preview requests
- Removed Regex/HTML Support. Not needed unless we explicitly decide to fix it. 
- Switch default source to JSON API
- Add support for order:popularity and order:quality modifiers among others
- Improve error handling for invalid posts