### PR TITLE
Add format filter for APNG encoding in ffmpeg

### DIFF
--- a/src/lib/src/external/ffmpeg.cpp
+++ b/src/lib/src/external/ffmpeg.cpp
@@ -143,7 +143,7 @@ QString FFmpeg::convertUgoira(const QString &file, const QList<QPair<QString, in
 	if (extension == QStringLiteral("gif")) {
 		params.append({ "-filter_complex", "[0:v]split[a][b];[a]palettegen=stats_mode=diff[p];[b][p]paletteuse=dither=bayer:bayer_scale=5:diff_mode=rectangle", "-fps_mode", "passthrough" });
 	} else if (extension == QStringLiteral("apng")) {
-		params.append({ "-c:v", "apng", "-plays", "0", "-fps_mode", "passthrough" });
+		params.append({ "-vf", "format=rgba", "-c:v", "apng", "-plays", "0", "-fps_mode", "passthrough" });
 	} else if (extension == QStringLiteral("webp")) {
 		params.append({ "-c:v", "libwebp_anim", "-pix_fmt", "yuva420p", "-lossless", "0", "-compression_level", "5", "-quality", "100", "-loop", "0", "-fps_mode", "passthrough" });
 	} else if (extension == QStringLiteral("webm")) {


### PR DESCRIPTION
The `-vf format=rgba` will normalize all frames to true-color RGBA before the APNG encoder processes them, avoiding the palette conflict.

```log
[04:10:53.838][Info] Loading image from `https://cdn.donmai.us/original/6a/7b/6a7bf363af46f5051628a4dfb5bd8cbf.zip` 1
[04:10:53.874][Info] Not enough information to directly load the image (from blacklist: 0 / from file url: 0 / from filename tags: 1/2)
[04:10:53.874][Info] Loading image details from `https://danbooru.donmai.us/posts/10491719`
[04:10:54.082][Info] Loading image ugoira details from `https://danbooru.donmai.us/posts/10491719.json?only=media_metadata`
[04:10:54.997][Info] Loading and saving image from `https://cdn.donmai.us/original/6a/7b/__sameko_saba_indie_virtual_youtuber_drawn_by_waterring__6a7bf363af46f5051628a4dfb5bd8cbf.zip` in `C:\Users\jelly\Grabber\Downloads\ani\6a7bf363af46f5051628a4dfb5bd8cbf.zip`
[04:10:55.278][Info] Extracting zip `C:\Users\jelly\Grabber\Downloads\ani\6a7bf363af46f5051628a4dfb5bd8cbf.zip` to `C:/Users/jelly/AppData/Local/Temp/Grabber-Ziovuw`
[04:10:56.505][Error] [FFmpeg] [apng @ 0000013621001940] Input contains more than one unique palette. APNG does not support multiple palettes.

[vost#0:0/apng @ 00000136210013c0] [enc:apng @ 0000013620b97b00] Error submitting video frame to the encoder

[vost#0:0/apng @ 00000136210013c0] [enc:apng @ 0000013620b97b00] Error encoding a frame: Operation not permitted

[vost#0:0/apng @ 00000136210013c0] Task finished with error code: -1 (Operation not permitted)

[vost#0:0/apng @ 00000136210013c0] Terminating thread with return code -1 (Operation not permitted)
[04:10:56.507][Warning] Cleaning up failed conversion target file: `C:/Users/jelly/Grabber/Downloads/ani\6a7bf363af46f5051628a4dfb5bd8cbf.apng`
```