### PR TITLE
[*] Fix removed tags persistence, styling, and UI integration. Moves …

### DIFF
--- a/src/gui-qml/src/components/settings/Settings.qml
+++ b/src/gui-qml/src/components/settings/Settings.qml
@@ -112,15 +112,18 @@ Item {
         def: false
         obj: root.obj
     }
-    property Setting removedTags: Setting {
-        key: "ignoredtags"
-        def: ""
-        obj: root.obj
+    property var removedTags: Item {
+        property string value: backend.getRemoved()
+        function setValue(val) {
+            backend.setRemoved(val)
+            value = val
+        }
     }
     property var ignoredTags: Item {
         property string value: backend.getIgnored()
         function setValue(val) {
             backend.setIgnored(val)
+            value = val
         }
     }
     property Setting viewer_viewSamples: Setting {
@@ -288,6 +291,11 @@ Item {
     }
     property Setting coloring_colors_ignoreds: Setting {
         key: "Coloring/Colors/ignoreds"
+        def: ""
+        obj: root.obj
+    }
+    property Setting coloring_colors_removeds: Setting {
+        key: "Coloring/Colors/removeds"
         def: ""
         obj: root.obj
     }

--- a/src/gui-qml/src/components/settings/pages/AppearanceTagsSettingsPage.qml
+++ b/src/gui-qml/src/components/settings/pages/AppearanceTagsSettingsPage.qml
@@ -70,6 +70,11 @@ ColumnLayout {
         setting: gSettings.coloring_colors_ignoreds
         Layout.fillWidth: true
     }
+    ColorPickerSetting {
+        name: qsTr("Removed")
+        setting: gSettings.coloring_colors_removeds
+        Layout.fillWidth: true
+    }
 
     Item {
         Layout.fillHeight: true

--- a/src/gui-qml/src/components/settings/pages/BlacklistSettingsPage.qml
+++ b/src/gui-qml/src/components/settings/pages/BlacklistSettingsPage.qml
@@ -35,7 +35,7 @@ ColumnLayout {
     }
     TextAreaSetting {
         name: qsTr("Removed tags")
-        subtitle: qsTr("These won't be taken into account when saving the image.")
+        subtitle: qsTr("One per line. These won't be taken into account when saving the image.")
         setting: gSettings.removedTags
         Layout.fillWidth: true
     }

--- a/src/gui-qml/src/main-screen.cpp
+++ b/src/gui-qml/src/main-screen.cpp
@@ -250,3 +250,13 @@ void MainScreen::setIgnored(const QString &ignored)
 {
 	m_profile->setIgnored(ignored.split('\n', Qt::SkipEmptyParts));
 }
+
+QString MainScreen::getRemoved()
+{
+	return m_profile->getRemoved().toString();
+}
+
+void MainScreen::setRemoved(const QString &removed)
+{
+	m_profile->setRemoved(removed.split('\n', Qt::SkipEmptyParts));
+}

--- a/src/gui-qml/src/main-screen.h
+++ b/src/gui-qml/src/main-screen.h
@@ -49,6 +49,8 @@ class MainScreen : public QObject
 		void setBlacklist(const QString &blacklist);
 		QString getIgnored();
 		void setIgnored(const QString &ignored);
+		QString getRemoved();
+		void setRemoved(const QString &removed);
 		void addFavorite(const QString &query, const QString &siteUrl);
 		void removeFavorite(const QString &query);
 		void loadSuggestions(const QString &prefix, int limit);

--- a/src/gui/src/settings/options-window.cpp
+++ b/src/gui/src/settings/options-window.cpp
@@ -255,8 +255,8 @@ OptionsWindow::OptionsWindow(Profile *profile, ThemeLoader *themeLoader, QWidget
 	ui->checkDownloadBlacklisted->setChecked(settings->value("downloadblacklist", false).toBool());
 	new SearchSyntaxHighlighter(false, ui->textBlacklist->document());
 
-	// Ignored tags
-	ui->textRemovedTags->setPlainText(settings->value("ignoredtags").toString());
+	// Ignored / removed tags
+	ui->textRemovedTags->setPlainText(profile->getRemoved().toString());
 	ui->textIgnoredTags->setPlainText(profile->getIgnored().join('\n'));
 
 	// Monitoring
@@ -483,6 +483,7 @@ OptionsWindow::OptionsWindow(Profile *profile, ThemeLoader *themeLoader, QWidget
 			ui->lineColoringKeptForLater->setText(settings->value("keptForLater", "#000000").toString());
 			ui->lineColoringBlacklisteds->setText(settings->value("blacklisteds", "#000000").toString());
 			ui->lineColoringIgnoreds->setText(settings->value("ignoreds", "#999999").toString());
+			ui->lineColoringRemoveds->setText(settings->value("removeds", "#6e6e6e").toString());
 		settings->endGroup();
 		settings->beginGroup("Fonts");
 			ui->lineColoringArtists->setFont(qFontFromString(settings->value("artists").toString()));
@@ -497,6 +498,7 @@ OptionsWindow::OptionsWindow(Profile *profile, ThemeLoader *themeLoader, QWidget
 			ui->lineColoringKeptForLater->setFont(qFontFromString(settings->value("keptForLater").toString()));
 			ui->lineColoringBlacklisteds->setFont(qFontFromString(settings->value("blacklisteds").toString()));
 			ui->lineColoringIgnoreds->setFont(qFontFromString(settings->value("ignoreds").toString()));
+			ui->lineColoringRemoveds->setFont(qFontFromString(settings->value("removeds").toString()));
 		settings->endGroup();
 		settings->beginGroup("Borders");
 			ui->lineColoringFavoritesBorder->setText(settings->value("favorites", "#ffc0cb").toString());
@@ -1063,6 +1065,8 @@ void OptionsWindow::on_lineColoringBlacklistedsBorder_textChanged()
 { setColor(ui->lineColoringBlacklistedsBorder); }
 void OptionsWindow::on_lineColoringIgnoreds_textChanged()
 { setColor(ui->lineColoringIgnoreds); }
+void OptionsWindow::on_lineColoringRemoveds_textChanged()
+{ setColor(ui->lineColoringRemoveds); }
 void OptionsWindow::on_lineBorderColor_textChanged()
 { setColor(ui->lineBorderColor); }
 
@@ -1094,6 +1098,8 @@ void OptionsWindow::on_buttonColoringBlacklistedsBorderColor_clicked()
 { setColor(ui->lineColoringBlacklistedsBorder, true); }
 void OptionsWindow::on_buttonColoringIgnoredsColor_clicked()
 { setColor(ui->lineColoringIgnoreds, true); }
+void OptionsWindow::on_buttonColoringRemovedsColor_clicked()
+{ setColor(ui->lineColoringRemoveds, true); }
 void OptionsWindow::on_buttonBorderColor_clicked()
 { setColor(ui->lineBorderColor, true); }
 
@@ -1121,6 +1127,8 @@ void OptionsWindow::on_buttonColoringBlacklistedsFont_clicked()
 { setFont(ui->lineColoringBlacklisteds); }
 void OptionsWindow::on_buttonColoringIgnoredsFont_clicked()
 { setFont(ui->lineColoringIgnoreds); }
+void OptionsWindow::on_buttonColoringRemovedsFont_clicked()
+{ setFont(ui->lineColoringRemoveds); }
 
 void OptionsWindow::on_lineImageBackgroundColor_textChanged()
 { setColor(ui->lineImageBackgroundColor); }
@@ -1256,8 +1264,8 @@ void OptionsWindow::save()
 	settings->setValue("warnblacklisted", ui->checkWarnBlacklisted->isChecked());
 	settings->setValue("downloadblacklist", ui->checkDownloadBlacklisted->isChecked());
 
-	// Ignored tags
-	m_profile->setRemovedTags(ui->textRemovedTags->toPlainText());
+	// Ignored / removed tags
+	m_profile->setRemoved(ui->textRemovedTags->toPlainText().split('\n', Qt::SkipEmptyParts));
 	m_profile->setIgnored(ui->textIgnoredTags->toPlainText().split('\n', Qt::SkipEmptyParts));
 
 	// Monitoring
@@ -1523,6 +1531,7 @@ void OptionsWindow::save()
 			settings->setValue("keptForLater", ui->lineColoringKeptForLater->text());
 			settings->setValue("blacklisteds", ui->lineColoringBlacklisteds->text());
 			settings->setValue("ignoreds", ui->lineColoringIgnoreds->text());
+			settings->setValue("removeds", ui->lineColoringRemoveds->text());
 		settings->endGroup();
 		settings->beginGroup("Fonts");
 			settings->setValue("artists", ui->lineColoringArtists->font().toString());
@@ -1537,6 +1546,7 @@ void OptionsWindow::save()
 			settings->setValue("keptForLater", ui->lineColoringKeptForLater->font().toString());
 			settings->setValue("blacklisteds", ui->lineColoringBlacklisteds->font().toString());
 			settings->setValue("ignoreds", ui->lineColoringIgnoreds->font().toString());
+			settings->setValue("removeds", ui->lineColoringRemoveds->font().toString());
 		settings->endGroup();
 		settings->beginGroup("Borders");
 			settings->setValue("favorites", ui->lineColoringFavoritesBorder->text());

--- a/src/gui/src/settings/options-window.h
+++ b/src/gui/src/settings/options-window.h
@@ -51,6 +51,7 @@ class OptionsWindow : public QDialog
 		void on_lineColoringBlacklisteds_textChanged();
 		void on_lineColoringBlacklistedsBorder_textChanged();
 		void on_lineColoringIgnoreds_textChanged();
+		void on_lineColoringRemoveds_textChanged();
 		void on_buttonColoringArtistsColor_clicked();
 		void on_buttonColoringCirclesColor_clicked();
 		void on_buttonColoringCopyrightsColor_clicked();
@@ -65,6 +66,7 @@ class OptionsWindow : public QDialog
 		void on_buttonColoringBlacklistedsColor_clicked();
 		void on_buttonColoringBlacklistedsBorderColor_clicked();
 		void on_buttonColoringIgnoredsColor_clicked();
+		void on_buttonColoringRemovedsColor_clicked();
 		void on_buttonColoringArtistsFont_clicked();
 		void on_buttonColoringCirclesFont_clicked();
 		void on_buttonColoringCopyrightsFont_clicked();
@@ -77,6 +79,7 @@ class OptionsWindow : public QDialog
 		void on_buttonColoringKeptForLaterFont_clicked();
 		void on_buttonColoringBlacklistedsFont_clicked();
 		void on_buttonColoringIgnoredsFont_clicked();
+		void on_buttonColoringRemovedsFont_clicked();
 		void on_lineBorderColor_textChanged();
 		void on_buttonBorderColor_clicked();
 		void on_buttonFilenamePlus_clicked();

--- a/src/gui/src/settings/options-window.ui
+++ b/src/gui/src/settings/options-window.ui
@@ -5174,6 +5174,34 @@
           </item>
          </layout>
         </item>
+        <item row="12" column="0">
+         <widget class="QLabel" name="labelColoringRemoveds">
+          <property name="text">
+           <string>Removed</string>
+          </property>
+         </widget>
+        </item>
+        <item row="12" column="1">
+         <layout class="QHBoxLayout" name="layoutColoringRemoveds">
+          <item>
+           <widget class="QLineEdit" name="lineColoringRemoveds"/>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonColoringRemovedsColor">
+            <property name="text">
+             <string>Color</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonColoringRemovedsFont">
+            <property name="text">
+             <string>Font</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
        </layout>
        <zorder>labelColoringArtists</zorder>
        <zorder>labelColoringSeries</zorder>
@@ -5182,6 +5210,7 @@
        <zorder>labelColoringGenerals</zorder>
        <zorder>labelColoringFavorites</zorder>
        <zorder>labelColoringIgnoreds</zorder>
+       <zorder>labelColoringRemoveds</zorder>
        <zorder>labelColoringCircles</zorder>
        <zorder>labelColoringSpecies</zorder>
        <zorder>labelColoringKeptForLater</zorder>
@@ -6154,6 +6183,9 @@
   <tabstop>lineColoringIgnoreds</tabstop>
   <tabstop>buttonColoringIgnoredsColor</tabstop>
   <tabstop>buttonColoringIgnoredsFont</tabstop>
+  <tabstop>lineColoringRemoveds</tabstop>
+  <tabstop>buttonColoringRemovedsColor</tabstop>
+  <tabstop>buttonColoringRemovedsFont</tabstop>
   <tabstop>spinMainMargins</tabstop>
   <tabstop>spinServerBorders</tabstop>
   <tabstop>lineBorderColor</tabstop>

--- a/src/gui/src/tag-context-menu.cpp
+++ b/src/gui/src/tag-context-menu.cpp
@@ -43,7 +43,7 @@ TagContextMenu::TagContextMenu(QString tag, QList<Tag> allTags, QUrl browserUrl,
 	}
 
 	// Removed tags
-	if (profile->getRemovedTags().contains(m_tag)) {
+	if (profile->getRemoved().contains(m_tag)) {
 		addAction(QIcon(":/images/icons/eye-plus.png"), tr("Don't remove"), this, &TagContextMenu::unremove);
 	} else {
 		addAction(QIcon(":/images/icons/eye-minus.png"), tr("Remove"), this, &TagContextMenu::remove);
@@ -102,11 +102,12 @@ void TagContextMenu::unignore()
 
 void TagContextMenu::remove()
 {
-	m_profile->getRemovedTags().add(m_tag);
+	m_profile->addRemoved(m_tag);
 }
+
 void TagContextMenu::unremove()
 {
-	m_profile->getRemovedTags().remove(m_tag);
+	m_profile->removeRemoved(m_tag);
 }
 
 void TagContextMenu::blacklist()

--- a/src/lib/src/models/filtering/tag-filter-list.cpp
+++ b/src/lib/src/models/filtering/tag-filter-list.cpp
@@ -1,11 +1,13 @@
 #include "tag-filter-list.h"
 #include <QRegularExpression>
+#include <QStringList>
 #include "tags/tag.h"
 
 
 void TagFilterList::add(const QString &word)
 {
 	if (word.contains('*')) {
+		m_starTagStrings.insert(word);
 		m_starTags.insert(QRegularExpression::fromWildcard(word, Qt::CaseInsensitive));
 	} else {
 		m_rawTags.insert(word);
@@ -22,15 +24,23 @@ void TagFilterList::add(const QStringList &words)
 void TagFilterList::remove(const QString &word)
 {
 	if (word.contains('*')) {
+		m_starTagStrings.remove(word);
 		m_starTags.remove(QRegularExpression::fromWildcard(word, Qt::CaseInsensitive));
 	} else {
-		m_rawTags.remove(word);
+		for (auto it = m_rawTags.begin(); it != m_rawTags.end(); ) {
+			if (it->compare(word, Qt::CaseInsensitive) == 0) {
+				it = m_rawTags.erase(it);
+			} else {
+				++it;
+			}
+		}
 	}
 }
 
 void TagFilterList::clear()
 {
 	m_rawTags.clear();
+	m_starTagStrings.clear();
 	m_starTags.clear();
 }
 
@@ -39,11 +49,18 @@ QList<Tag> TagFilterList::filterTags(const QList<Tag> &tags) const
 	QList<Tag> ret;
 
 	for (const Tag &tag : tags) {
-		if (m_rawTags.contains(tag.text())) {
+		bool removed = false;
+
+		for (const QString &raw : m_rawTags) {
+			if (raw.compare(tag.text(), Qt::CaseInsensitive) == 0) {
+				removed = true;
+				break;
+			}
+		}
+		if (removed) {
 			continue;
 		}
 
-		bool removed = false;
 		for (const QRegularExpression &reg : m_starTags) {
 			if (reg.match(tag.text()).hasMatch()) {
 				removed = true;
@@ -60,5 +77,38 @@ QList<Tag> TagFilterList::filterTags(const QList<Tag> &tags) const
 
 bool TagFilterList::contains(const QString &word) const
 {
-	return m_rawTags.contains(word);
+	for (const QString &raw : m_rawTags) {
+		if (raw.compare(word, Qt::CaseInsensitive) == 0) {
+			return true;
+		}
+	}
+
+	for (const QRegularExpression &reg : m_starTags) {
+		if (reg.match(word).hasMatch()) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+QStringList TagFilterList::toStringList() const
+{
+	QStringList ret;
+
+	for (const QString &raw : m_rawTags) {
+		ret.append(raw);
+	}
+	for (const QString &wildcard : m_starTagStrings) {
+		ret.append(wildcard);
+	}
+
+	ret.removeDuplicates();
+	ret.sort();
+	return ret;
+}
+
+QString TagFilterList::toString() const
+{
+	return toStringList().join("\n");
 }

--- a/src/lib/src/models/filtering/tag-filter-list.h
+++ b/src/lib/src/models/filtering/tag-filter-list.h
@@ -4,9 +4,9 @@
 #include <QList>
 #include <QSet>
 
-
 class QRegularExpression;
 class QString;
+class QStringList;
 class Tag;
 
 /**
@@ -24,8 +24,12 @@ class TagFilterList
 		QList<Tag> filterTags(const QList<Tag> &tags) const;
 		bool contains(const QString &word) const;
 
+		QStringList toStringList() const;
+		QString toString() const;
+
 	private:
 		QSet<QString> m_rawTags;
+		QSet<QString> m_starTagStrings;
 		QSet<QRegularExpression> m_starTags;
 };
 

--- a/src/lib/src/models/image.cpp
+++ b/src/lib/src/models/image.cpp
@@ -1234,7 +1234,7 @@ QMap<QString, Token> Image::generateTokens(Profile *profile) const
 {
 	const QSettings *settings = profile->getSettings();
 	const QStringList &ignore = profile->getIgnored();
-	const TagFilterList &remove = profile->getRemovedTags();
+	const TagFilterList &remove = profile->getRemoved();
 
 	QMap<QString, Token> tokens;
 	QMap<QString, QStringList> details;

--- a/src/lib/src/models/profile.cpp
+++ b/src/lib/src/models/profile.cpp
@@ -116,7 +116,21 @@ Profile::Profile(QString path)
 	}
 
 	// Load removed
-	m_removedTags.add(splitStringMulti({ ' ', '\n' }, m_settings->value("ignoredtags").toString(), true));
+	QFile fileRemoved(m_path + "/removed.txt");
+	if (fileRemoved.open(QFile::ReadOnly | QFile::Text)) {
+		QString rem = fileRemoved.readAll();
+		fileRemoved.close();
+
+		m_removedTags.add(rem.split("\n", Qt::SkipEmptyParts));
+	} else {
+		// Legacy migration from old settings key
+		const QString legacyRemoved = m_settings->value("ignoredtags").toString();
+		if (!legacyRemoved.isEmpty()) {
+			m_removedTags.add(splitStringMulti({ ' ', '\n' }, legacyRemoved, true));
+			syncRemoved();
+			m_settings->remove("ignoredtags");
+		}
+	}
 
 	// Make a backup of MD5s in case the multi-location change broke everything
 	if (QFile::exists(m_path + "/md5s.txt") && !QFile::exists(m_path + "/md5s.txt.bak")) {
@@ -232,6 +246,7 @@ void Profile::sync()
 	syncFavorites();
 	syncKeptForLater();
 	syncIgnored();
+	syncRemoved();
 	syncBlacklist();
 
 	// MD5s
@@ -281,6 +296,14 @@ void Profile::syncKeptForLater() const
 void Profile::syncIgnored() const
 {
 	safeWriteFile(m_path + "/ignore.txt", m_ignored.join("\r\n").toUtf8());
+}
+void Profile::syncRemoved() const
+{
+	if (m_path.isEmpty()) {
+		return;
+	}
+
+	safeWriteFile(m_path + "/removed.txt", m_removedTags.toString().toUtf8());
 }
 void Profile::syncBlacklist() const
 {
@@ -399,12 +422,29 @@ void Profile::removeIgnored(const QString &tag)
 	emit ignoredChanged();
 }
 
-void Profile::setRemovedTags(const QString &raw)
+void Profile::setRemoved(const QStringList &tags)
 {
 	m_removedTags.clear();
-	m_removedTags.add(splitStringMulti({ ' ', '\n' }, raw, true));
+	m_removedTags.add(tags);
 
-	m_settings->setValue("ignoredtags", raw);
+	syncRemoved();
+	emit removedChanged();
+}
+
+void Profile::addRemoved(const QString &tag)
+{
+	m_removedTags.add(tag);
+
+	syncRemoved();
+	emit removedChanged();
+}
+
+void Profile::removeRemoved(const QString &tag)
+{
+	m_removedTags.remove(tag);
+
+	syncRemoved();
+	emit removedChanged();
 }
 
 QPair<QString, QString> Profile::md5Action(const QString &md5, const QString &target)
@@ -539,7 +579,7 @@ QSettings *Profile::getSettings() const { return m_settings; }
 QList<Favorite> &Profile::getFavorites() { return m_favorites; }
 QStringList &Profile::getKeptForLater() { return m_keptForLater; }
 QStringList &Profile::getIgnored() { return m_ignored; }
-TagFilterList &Profile::getRemovedTags() { return m_removedTags; }
+TagFilterList &Profile::getRemoved() { return m_removedTags; }
 Commands &Profile::getCommands() { return *m_commands; }
 Exiftool &Profile::getExiftool() { return *m_exiftool; }
 QStringList &Profile::getAutoComplete() { return m_autoComplete; }

--- a/src/lib/src/models/profile.h
+++ b/src/lib/src/models/profile.h
@@ -37,6 +37,7 @@ class Profile : public QObject
 		void syncFavorites() const;
 		void syncKeptForLater() const;
 		void syncIgnored() const;
+		void syncRemoved() const;
 		void syncBlacklist() const;
 
 		// Temporary path
@@ -58,7 +59,9 @@ class Profile : public QObject
 		void removeIgnored(const QString &tag);
 
 		// Removed tags management
-		void setRemovedTags(const QString &raw);
+		void setRemoved(const QStringList &tags);
+		void addRemoved(const QString &tag);
+		void removeRemoved(const QString &tag);
 
 		// MD5 management
 		QPair<QString, QString> md5Action(const QString &md5, const QString &target);
@@ -91,7 +94,7 @@ class Profile : public QObject
 		QList<Favorite> &getFavorites();
 		QStringList &getKeptForLater();
 		QStringList &getIgnored();
-		TagFilterList &getRemovedTags();
+		TagFilterList &getRemoved();
 		Commands &getCommands();
 		Exiftool &getExiftool();
 		QStringList &getAutoComplete();
@@ -109,6 +112,7 @@ class Profile : public QObject
 		void favoritesChanged();
 		void keptForLaterChanged();
 		void ignoredChanged();
+		void removedChanged();
 		void sitesChanged();
 		void siteDeleted(Site *site);
 		void blacklistChanged();

--- a/src/lib/src/tags/tag-stylist.cpp
+++ b/src/lib/src/tags/tag-stylist.cpp
@@ -26,9 +26,53 @@ QStringList TagStylist::stylished(QList<Tag> tags, bool count, bool noUnderscore
 	}
 
 	// Generate style map
-	static const QStringList tlist { "artists", "circles", "copyrights", "characters", "species", "metas", "models", "generals", "favorites", "keptForLater", "blacklisteds", "ignoreds", "favorites" };
-	static const QStringList defaults { "#aa0000", "#55bbff", "#aa00aa", "#00aa00", "#ee6600", "#ee6600", "#0000ee", "#000000", "#ffc0cb", "#000000", "#000000", "#999999", "#ffcccc" };
-	static const QStringList defaultsDark { "#ff8888", "#55bbff", "#cc66cc", "#66cc66", "#ee6600", "#ee6600", "#0000ee", "#ffffff", "#ffc0cb", "#ffffff", "#000000", "#999999", "#ffcccc" };
+	static const QStringList tlist {
+		"artists",
+		"circles",
+		"copyrights",
+		"characters",
+		"species",
+		"metas",
+		"models",
+		"generals",
+		"favorites",
+		"keptForLater",
+		"blacklisteds",
+		"ignoreds",
+		"removeds"
+	};
+
+	static const QStringList defaults {
+		"#aa0000", /*artists*/
+		"#55bbff", /*circles*/
+		"#aa00aa", /*copyrights*/
+		"#00aa00", /*characters*/
+		"#ee6600", /*species*/
+		"#ee6600", /*metas*/
+		"#0000ee", /*models*/
+		"#000000", /*generals*/
+		"#ffc0cb", /*favorites*/
+		"#000000", /*keptForLater*/
+		"#000000", /*blacklisteds*/
+		"#999999", /*ignoreds*/
+		"#6e6e6e" /*removeds*/
+	};
+
+	static const QStringList defaultsDark {
+		"#ff8888", /*artists*/
+		"#55bbff", /*circles*/
+		"#cc66cc", /*copyrights*/
+		"#66cc66", /*characters*/
+		"#ee6600", /*species*/
+		"#ee6600", /*metas*/
+		"#0000ee", /*models*/
+		"#ffffff", /*generals*/
+		"#ffc0cb", /*favorites*/
+		"#ffffff", /*keptForLater*/
+		"#000000", /*blacklisteds*/
+		"#999999", /*ignoreds*/
+		"#6e6e6e" /*removeds*/
+	};
 	QMap<QString, QString> styles;
 	for (const QString &key : tlist) {
 		const QString color = m_profile->getSettings()->value("Coloring/Colors/" + key, (dark ? defaultsDark : defaults).at(tlist.indexOf(key))).toString();
@@ -68,6 +112,9 @@ QString TagStylist::stylished(const Tag &tag, const QMap<QString, QString> &styl
 	}
 	if (m_profile->getIgnored().contains(txt, Qt::CaseInsensitive)) {
 		key = "ignoreds";
+	}
+	if (m_profile->getRemoved().contains(txt)) {
+		key = "removeds";
 	}
 	for (const QString &t : qAsConst(m_profile->getKeptForLater())) {
 		if (t == txt) {

--- a/src/lib/tests/src/filename/filename-test.cpp
+++ b/src/lib/tests/src/filename/filename-test.cpp
@@ -106,7 +106,7 @@ TEST_CASE("Filename")
 	auto *profile = pProfile.data();
 
 	auto *settings = profile->getSettings();
-	profile->setRemovedTags("");
+	profile->setRemoved({});
 	settings->setValue("Save/separator", " ");
 	settings->setValue("Save/character_value", "group");
 	settings->setValue("Save/character_multiple", "replaceAll");
@@ -197,15 +197,15 @@ TEST_CASE("Filename")
 			"%artist%/%copyright%/%character%/%md5%.%ext%",
 			"artist1/crossover/character1 character2/1bc29b36f623ba82aaf6724fd3b16718.jpg");
 	}
-	SECTION("PathIgnoredTags")
+	SECTION("PathRemovedTags")
 	{
-		profile->setRemovedTags("character1");
+		profile->setRemoved(QStringList() << "character1");
 		img = ImageFactory::build(site, details, profile);
 		assertPath(profile, img,
 			"%artist%/%copyright%/%character%/%md5%.%ext%",
 			"artist1/crossover/character2/1bc29b36f623ba82aaf6724fd3b16718.jpg");
 
-		profile->setRemovedTags("character*");
+		profile->setRemoved(QStringList() << "character*");
 		img = ImageFactory::build(site, details, profile);
 		assertPath(profile, img,
 			"%artist%/%copyright%/%character%/%md5%.%ext%",
@@ -216,6 +216,14 @@ TEST_CASE("Filename")
 		assertPath(profile, img,
 			"%artist%/%copyright%/%character%/%md5%.%ext%",
 			"artist1/crossover/1bc29b36f623ba82aaf6724fd3b16718.jpg");
+	}
+	SECTION("PathRemovedTagsMultiple") //testing multiple removed tags
+	{
+		profile->setRemoved(QStringList() << "character1" << "copyright1");
+		img = ImageFactory::build(site, details, profile);
+		assertPath(profile, img,
+			"%artist%/%copyright%/%character%/%md5%.%ext%",
+			"artist1/copyright2/character2/1bc29b36f623ba82aaf6724fd3b16718.jpg");
 	}
 	SECTION("PathEmptyDirs")
 	{

--- a/src/lib/tests/src/tags/tag-stylist-test.cpp
+++ b/src/lib/tests/src/tags/tag-stylist-test.cpp
@@ -72,6 +72,22 @@ TEST_CASE("TagStylist")
 		REQUIRE_THAT(actual.toStdString(), Matches(expected));
 	}
 
+	SECTION("Removed")
+	{
+	settings.setValue("Coloring/Fonts/removeds", ",8.25,-1,5,50,0,0,0,0,0");
+	settings.setValue("Coloring/Colors/removeds", "#6e6e6e");
+
+	Tag tag("tag_text", "artist", 123, QStringList() << "related1" << "related2" << "related3");
+
+	Profile pro(&settings, QList<Favorite>());
+	pro.addRemoved("tag_text");
+
+	TagStylist stylist(&pro);
+	QString actual = stylist.stylished(QList<Tag>() << tag).join("");
+	std::string expected = "<a href=\"tag_text\" style=\"color:#6e6e6e; font-family:'[^']*'; font-size:[0-9]+pt; font-style:normal; font-weight:400; text-decoration:none;\">tag_text</a>";
+	REQUIRE_THAT(actual.toStdString(), Matches(expected));
+	}
+
 	SECTION("Blacklisted")
 	{
 		settings.setValue("Coloring/Fonts/blacklisteds", ",8.25,-1,5,50,0,0,0,0,0");


### PR DESCRIPTION
[*] Fix removed tags persistence, styling, and UI integration. Moves removed tags to new removed.txt file, similar to ignored.txt. Migrates profile's existing removed tags list to that file when it is first created so no data is lost. Fixes #3156.