### PR TITLE
fix(Gelbooru 0.2): use rule34 dapi tag_info JSON for details

### DIFF
--- a/src/sites/Gelbooru (0.2)/api.rule34.xxx/defaults.ini
+++ b/src/sites/Gelbooru (0.2)/api.rule34.xxx/defaults.ini
@@ -8,3 +8,8 @@ throttle_page=3
 throttle_details=2
 throttle_image=1
 throttle_retry=61
+
+[sources]
+usedefault=false
+source_1=json
+source_2=xml

--- a/src/sites/Gelbooru (0.2)/api.rule34.xxx/defaults.ini
+++ b/src/sites/Gelbooru (0.2)/api.rule34.xxx/defaults.ini
@@ -1,0 +1,10 @@
+[General]
+name=Rule34.xxx
+ssl=true
+referer_image=page
+
+[download]
+throttle_page=3
+throttle_details=2
+throttle_image=1
+throttle_retry=61

--- a/src/sites/Gelbooru (0.2)/model.ts
+++ b/src/sites/Gelbooru (0.2)/model.ts
@@ -1,5 +1,19 @@
+const tagTypeMap: Record<string, string> = {
+    "tag": "general",
+    "metadata": "meta",
+};
+
 function completeImage(img: IImage): IImage {
     img.author = (img as any).owner;
+
+    if ("tag_info" in img) {
+        const tagInfo: Array<{ tag: string; type: string; count: number }> = img["tag_info"] as any;
+        img.tags = tagInfo.map((tag) => ({
+            name: tag.tag,
+            type: tagTypeMap[tag.type] || tag.type,
+            count: tag.count,
+        }));
+    }
 
     if ((!img.file_url || img.file_url.length < 5) && img.preview_url) {
         img.file_url = img.preview_url
@@ -94,6 +108,54 @@ export const source: ISource = {
                 },
             },
         },
+        json: {
+            name: "JSON",
+            auth: [],
+            maxLimit: 100,
+            search: {
+                url: (query: ISearchQuery, opts: IUrlOptions): string | IError => {
+                    const page: number = query.page - 1;
+                    const search: string = query.search.replace(/(^| )order:/gi, "$1sort:");
+                    const fav = search.match(/(?:^| )fav:(\d+)(?:$| )/);
+                    if (fav) {
+                        return { error: "JSON API cannot search favorites" };
+                    }
+                    return "/index.php?page=dapi&s=post&q=index&limit=" + opts.limit + "&pid=" + page + "&tags=" + encodeURIComponent(search) + "&json=1";
+                },
+                parse: (src: string): IParsedSearch | IError => {
+                    let parsed = JSON.parse(src);
+
+                    // Handle the old format
+                    if (Array.isArray(parsed)) {
+                        parsed = {
+                            "@attributes": {},
+                            "post": parsed,
+                        };
+                    }
+
+                    const images: IImage[] = [];
+                    for (const image of parsed["post"]) {
+                        images.push(completeImage(image));
+                    }
+
+                    return {
+                        images,
+                        imageCount: parsed["@attributes"]["count"],
+                    };
+                },
+            },
+            details: {
+                url: (id: string, md5: string, opts: IUrlDetailsOptions): string => {
+                    return "/index.php?page=dapi&s=post&q=index&id=" + id + "&fields=tag_info&json=1";
+                },
+                parse: (src: string): IImage => {
+                    const parsed = JSON.parse(src);
+                    const post = "post" in parsed ? parsed["post"] : parsed;
+                    const image = Array.isArray(post) ? post[0] : post;
+                    return completeImage(image);
+                },
+            },
+        },
         html: {
             name: "Regex",
             auth: [],
@@ -139,39 +201,10 @@ export const source: ISource = {
             },
             details: {
                 url: (id: string, md5: string, opts: IUrlDetailsOptions): string => {
-                    // rule34.xxx exposes typed tags through the dapi JSON endpoint with
-                    // fields=tag_info, letting us avoid the Cloudflare-protected HTML
-                    // post page used by sibling sites.
-                    if (opts.baseUrl && opts.baseUrl.indexOf("rule34.xxx") !== -1) {
-                        return "/index.php?page=dapi&s=post&q=index&id=" + id + "&fields=tag_info&json=1";
-                    }
                     const baseUrl = opts.baseUrl.replace("//api.", "//");
                     return baseUrl + "/index.php?page=post&s=view&id=" + id;
                 },
                 parse: (src: string): IParsedDetails => {
-                    const head = src.replace(/^\s+/, "").charAt(0);
-                    if (head === "[" || head === "{") {
-                        const data = JSON.parse(src);
-                        const post = (Array.isArray(data) ? data[0] : data) || {};
-                        const typeMap: Record<string, string> = {
-                            "tag": "general",
-                            "copyright": "copyright",
-                            "character": "character",
-                            "artist": "artist",
-                            "metadata": "meta",
-                        };
-                        const tagInfo: Array<{ tag: string; type: string; count: number }> = post.tag_info || [];
-                        const tags = tagInfo.map((t) => ({
-                            name: t.tag,
-                            type: typeMap[t.type] || t.type,
-                            count: t.count,
-                        }));
-                        return {
-                            tags,
-                            imageUrl: post.file_url,
-                            source: post.source,
-                        };
-                    }
                     return {
                         tags: Grabber.regexToTags('<li class="tag-type-(?<type>[^"]+)">(?:[^<]*(?:<span[^>]*>[^<]*)?<a[^>]*>[^<]*</a>(?:[^<]*</span>)?)*[^<]*<a[^>]*>(?<name>[^<]*)</a>[^<]*<span[^>]*>(?<count>\\d+)</span>[^<]*</li>', src),
                         imageUrl: Grabber.regexToConst("url", '<img[^>]+src="([^"]+)"[^>]+onclick="Note\\.toggle\\(\\);"[^>]*/>', src),

--- a/src/sites/Gelbooru (0.2)/model.ts
+++ b/src/sites/Gelbooru (0.2)/model.ts
@@ -139,10 +139,39 @@ export const source: ISource = {
             },
             details: {
                 url: (id: string, md5: string, opts: IUrlDetailsOptions): string => {
+                    // rule34.xxx exposes typed tags through the dapi JSON endpoint with
+                    // fields=tag_info, letting us avoid the Cloudflare-protected HTML
+                    // post page used by sibling sites.
+                    if (opts.baseUrl && opts.baseUrl.indexOf("rule34.xxx") !== -1) {
+                        return "/index.php?page=dapi&s=post&q=index&id=" + id + "&fields=tag_info&json=1";
+                    }
                     const baseUrl = opts.baseUrl.replace("//api.", "//");
                     return baseUrl + "/index.php?page=post&s=view&id=" + id;
                 },
                 parse: (src: string): IParsedDetails => {
+                    const head = src.replace(/^\s+/, "").charAt(0);
+                    if (head === "[" || head === "{") {
+                        const data = JSON.parse(src);
+                        const post = (Array.isArray(data) ? data[0] : data) || {};
+                        const typeMap: Record<string, string> = {
+                            "tag": "general",
+                            "copyright": "copyright",
+                            "character": "character",
+                            "artist": "artist",
+                            "metadata": "meta",
+                        };
+                        const tagInfo: Array<{ tag: string; type: string; count: number }> = post.tag_info || [];
+                        const tags = tagInfo.map((t) => ({
+                            name: t.tag,
+                            type: typeMap[t.type] || t.type,
+                            count: t.count,
+                        }));
+                        return {
+                            tags,
+                            imageUrl: post.file_url,
+                            source: post.source,
+                        };
+                    }
                     return {
                         tags: Grabber.regexToTags('<li class="tag-type-(?<type>[^"]+)">(?:[^<]*(?:<span[^>]*>[^<]*)?<a[^>]*>[^<]*</a>(?:[^<]*</span>)?)*[^<]*<a[^>]*>(?<name>[^<]*)</a>[^<]*<span[^>]*>(?<count>\\d+)</span>[^<]*</li>', src),
                         imageUrl: Grabber.regexToConst("url", '<img[^>]+src="([^"]+)"[^>]+onclick="Note\\.toggle\\(\\);"[^>]*/>', src),


### PR DESCRIPTION
Avoids the Cloudflare wall on rule34.xxx by switching the details fetch from the HTML post page to the dapi JSON endpoint with fields=tag_info. This is the actual canonical way rule34.xxx wants API users to do it according to the API page.

I run many monitors, with correct delay settings to obey their API rate limits I have not had any problems at all since I made this change.

Refs #3621, #3420.

### Addendum

I also added safe defaults for api.rule34.xxx, the default rate limit is 60 requests per minute. The limits I added are extra-safe but still optimal, 17% below the limit, so even if there's any muckery involved with request timing and so on users won't go over and hit the wall.

In detail:
* Page delay of 3s
* Detail delay of 2s
* Image delay of 1s
* Retry delay of 61s

Technically you can run a Page delay of 2s to be bang on the 60 requests per minute limit, but it has no safety margin, so these are safer. Absolutely definitely beats flashbanging the API and getting rate limited to oblivion.

No tricks or workarounds here, we're just being polite about our usage of their API and obeying their restrictions, which feels like the correct thing to do given they actually cared enough to clearly inform us, which many APIs don't do.