### PR TITLE
Gelbooru (0.2): handle XML error documents without crashing

### DIFF
--- a/src/sites/Gelbooru (0.2)/model.ts
+++ b/src/sites/Gelbooru (0.2)/model.ts
@@ -90,21 +90,20 @@ export const source: ISource = {
                     }
 
                     // Handle error messages
-                    if ("response" in parsed && parsed["response"]["@attributes"] && parsed["response"]["@attributes"]["success"] === "false") {
+                    if (parsed?.["response"]?.["@attributes"]?.["success"] === "false") {
                         return { error: parsed["response"]["@attributes"]["reason"] };
                     }
-
-                    // Some sites (e.g. api.rule34.xxx) return an <error> document, notably when unauthenticated
                     if ("error" in parsed) {
                         const error = parsed["error"];
                         return { error: typeof error === "string" ? error : String(error["#text"] || "Unknown API error") };
                     }
 
-                    if (!("posts" in parsed) || !parsed["posts"]) {
+                    // Validate the shape of the response
+                    if (!parsed?.["posts"]) {
                         return { error: "Invalid XML response (no posts found)" };
                     }
 
-                    const data = parsed.posts.post !== undefined ? Grabber.makeArray(parsed.posts.post) : [];
+                    const data = Grabber.makeArray(parsed.posts.post);
                     const images: IImage[] = [];
                     for (const image of data) {
                         if (image && "id" in image) {
@@ -114,10 +113,9 @@ export const source: ISource = {
                         }
                     }
 
-                    const attrs = parsed.posts["@attributes"];
                     return {
                         images,
-                        imageCount: attrs ? attrs["count"] : undefined,
+                        imageCount: parsed.posts["@attributes"]?.["count"],
                     };
                 },
             },

--- a/src/sites/Gelbooru (0.2)/model.ts
+++ b/src/sites/Gelbooru (0.2)/model.ts
@@ -85,13 +85,26 @@ export const source: ISource = {
                 },
                 parse: (src: string): IParsedSearch | IError => {
                     const parsed = Grabber.parseXML(src);
+                    if (!parsed) {
+                        return { error: "Invalid XML response" };
+                    }
 
                     // Handle error messages
-                    if ("response" in parsed && parsed["response"]["@attributes"]["success"] === "false") {
+                    if ("response" in parsed && parsed["response"]["@attributes"] && parsed["response"]["@attributes"]["success"] === "false") {
                         return { error: parsed["response"]["@attributes"]["reason"] };
                     }
 
-                    const data = Grabber.makeArray(parsed.posts.post);
+                    // Some sites (e.g. api.rule34.xxx) return an <error> document, notably when unauthenticated
+                    if ("error" in parsed) {
+                        const error = parsed["error"];
+                        return { error: typeof error === "string" ? error : String(error["#text"] || "Unknown API error") };
+                    }
+
+                    if (!("posts" in parsed) || !parsed["posts"]) {
+                        return { error: "Invalid XML response (no posts found)" };
+                    }
+
+                    const data = parsed.posts.post !== undefined ? Grabber.makeArray(parsed.posts.post) : [];
                     const images: IImage[] = [];
                     for (const image of data) {
                         if (image && "id" in image) {
@@ -101,9 +114,10 @@ export const source: ISource = {
                         }
                     }
 
+                    const attrs = parsed.posts["@attributes"];
                     return {
                         images,
-                        imageCount: parsed.posts["@attributes"]["count"],
+                        imageCount: attrs ? attrs["count"] : undefined,
                     };
                 },
             },


### PR DESCRIPTION
## What

`api.rule34.xxx` now requires API authentication and returns **HTTP 200** with an XML error document (`<error>Missing authentication. Go to api.rule34.xxx for more information</error>`) for unauthenticated API calls. The Gelbooru (0.2) XML search parser assumes `parsed.posts` always exists, so every page load crashes with:

```
[Warning] [api.rule34.xxx][Xml] Uncaught exception at line 75: TypeError: Cannot read property 'post' of undefined
```

`Grabber.parseXML` also returns `undefined` for non-XML bodies, which would crash the same way one line earlier (`"response" in parsed`).

## Changes

In the XML search `parse`:

- Guard against `parseXML` returning `undefined`
- Recognize `<error>` documents and return a proper error carrying the site's actual message, so the engine cleanly falls back to the next source (previously the fallback still happened, but via an uncaught JS exception with no useful message)
- Return an explicit error when the document has no `posts` element
- Keep genuinely empty result sets (a `posts` element with no children) as successful empty pages
- Guard the `@attributes` access for `imageCount`

No behavior change for well-formed responses.

## Testing

- Live api.rule34.xxx unauthenticated: XML source now fails with the site's own message ("Missing authentication...") and falls back to HTML cleanly; results load
- gelbooru.com, safebooru.org, tbib.org verified unaffected (safebooru/tbib XML APIs still work anonymously and parse as before)
- `tsc -p tsconfig.json` passes (repo's `npm run check`/tslint crashes on unmodified master due to a tslint/TypeScript 5 incompatibility, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
