### PR TITLE
feat: add site-specific blacklist shortcut

### DIFF
--- a/src/gui/src/tag-context-menu.cpp
+++ b/src/gui/src/tag-context-menu.cpp
@@ -5,6 +5,7 @@
 #include <QProcess>
 #include "functions.h"
 #include "models/profile.h"
+#include "models/site.h"
 #include "tags/tag.h"
 
 
@@ -111,6 +112,13 @@ void TagContextMenu::unremove()
 
 void TagContextMenu::blacklist()
 {
+	if (QApplication::keyboardModifiers().testFlag(Qt::ShiftModifier) && !m_sites.isEmpty()) {
+		for (const Site *site : qAsConst(m_sites)) {
+			m_profile->addBlacklistedTags({ "website:" + site->url(), m_tag });
+		}
+		return;
+	}
+
 	m_profile->addBlacklistedTag(m_tag);
 }
 void TagContextMenu::unblacklist()

--- a/src/gui/src/tag-context-menu.cpp
+++ b/src/gui/src/tag-context-menu.cpp
@@ -30,10 +30,19 @@ TagContextMenu::TagContextMenu(QString tag, QList<Tag> allTags, QUrl browserUrl,
 	}
 
 	// Blacklist
-	if (profile->getBlacklist().contains(m_tag)) {
-		addAction(QIcon(":/images/icons/eye-plus.png"), tr("Don't blacklist"), this, SLOT(unblacklist()));
+	// If the SHIFT key is pressed, add it as a site-specific blacklist
+	if (QApplication::keyboardModifiers().testFlag(Qt::ShiftModifier) && !m_sites.isEmpty()) {
+		if (profile->getBlacklist().contains({ "website:" + m_sites[0]->url(), m_tag })) {
+			addAction(QIcon(":/images/icons/eye-plus.png"), tr("Don't blacklist (site)"), this, SLOT(unblacklistSite()));
+		} else {
+			addAction(QIcon(":/images/icons/eye-minus.png"), tr("Blacklist (site)"), this, SLOT(blacklistSite()));
+		}
 	} else {
-		addAction(QIcon(":/images/icons/eye-minus.png"), tr("Blacklist"), this, SLOT(blacklist()));
+		if (profile->getBlacklist().contains(m_tag)) {
+			addAction(QIcon(":/images/icons/eye-plus.png"), tr("Don't blacklist"), this, SLOT(unblacklist()));
+		} else {
+			addAction(QIcon(":/images/icons/eye-minus.png"), tr("Blacklist"), this, SLOT(blacklist()));
+		}
 	}
 
 	// Ignored tags
@@ -112,27 +121,23 @@ void TagContextMenu::unremove()
 
 void TagContextMenu::blacklist()
 {
-	// If the SHIFT key is pressed, add it as a site-specific blacklist
-	if (QApplication::keyboardModifiers().testFlag(Qt::ShiftModifier) && !m_sites.isEmpty()) {
-		for (const Site *site : qAsConst(m_sites)) {
-			m_profile->addBlacklistedTags({ "website:" + site->url(), m_tag });
-		}
-		return;
-	}
-
 	m_profile->addBlacklistedTag(m_tag);
+}
+void TagContextMenu::blacklistSite()
+{
+	for (const Site *site : qAsConst(m_sites)) {
+		m_profile->addBlacklistedTags({ "website:" + site->url(), m_tag });
+	}
 }
 void TagContextMenu::unblacklist()
 {
-	// If the SHIFT key is pressed, add it as a site-specific blacklist
-	if (QApplication::keyboardModifiers().testFlag(Qt::ShiftModifier) && !m_sites.isEmpty()) {
-		for (const Site *site : qAsConst(m_sites)) {
-			m_profile->removeBlacklistedTags({ "website:" + site->url(), m_tag });
-		}
-		return;
-	}
-
 	m_profile->removeBlacklistedTag(m_tag);
+}
+void TagContextMenu::unblacklistSite()
+{
+	for (const Site *site : qAsConst(m_sites)) {
+		m_profile->removeBlacklistedTags({ "website:" + site->url(), m_tag });
+	}
 }
 
 void TagContextMenu::openInNewTab()

--- a/src/gui/src/tag-context-menu.cpp
+++ b/src/gui/src/tag-context-menu.cpp
@@ -112,6 +112,7 @@ void TagContextMenu::unremove()
 
 void TagContextMenu::blacklist()
 {
+	// If the SHIFT key is pressed, add it as a site-specific blacklist
 	if (QApplication::keyboardModifiers().testFlag(Qt::ShiftModifier) && !m_sites.isEmpty()) {
 		for (const Site *site : qAsConst(m_sites)) {
 			m_profile->addBlacklistedTags({ "website:" + site->url(), m_tag });
@@ -123,6 +124,14 @@ void TagContextMenu::blacklist()
 }
 void TagContextMenu::unblacklist()
 {
+	// If the SHIFT key is pressed, add it as a site-specific blacklist
+	if (QApplication::keyboardModifiers().testFlag(Qt::ShiftModifier) && !m_sites.isEmpty()) {
+		for (const Site *site : qAsConst(m_sites)) {
+			m_profile->removeBlacklistedTags({ "website:" + site->url(), m_tag });
+		}
+		return;
+	}
+
 	m_profile->removeBlacklistedTag(m_tag);
 }
 

--- a/src/gui/src/tag-context-menu.h
+++ b/src/gui/src/tag-context-menu.h
@@ -29,7 +29,9 @@ class TagContextMenu : public QMenu
 		void remove();
 		void unremove();
 		void blacklist();
+		void blacklistSite();
 		void unblacklist();
+		void unblacklistSite();
 		void openInNewTab();
 		void openInNewWindow();
 		void openInBrowser();

--- a/src/lib/src/models/profile.cpp
+++ b/src/lib/src/models/profile.cpp
@@ -536,6 +536,14 @@ void Profile::addBlacklistedTag(const QString &tag)
 	emit blacklistChanged();
 }
 
+void Profile::addBlacklistedTags(const QStringList &tags)
+{
+	m_blacklist.add(tags);
+
+	syncBlacklist();
+	emit blacklistChanged();
+}
+
 void Profile::removeBlacklistedTag(const QString &tag)
 {
 	m_blacklist.remove(tag);

--- a/src/lib/src/models/profile.cpp
+++ b/src/lib/src/models/profile.cpp
@@ -535,7 +535,6 @@ void Profile::addBlacklistedTag(const QString &tag)
 	syncBlacklist();
 	emit blacklistChanged();
 }
-
 void Profile::addBlacklistedTags(const QStringList &tags)
 {
 	m_blacklist.add(tags);
@@ -547,6 +546,13 @@ void Profile::addBlacklistedTags(const QStringList &tags)
 void Profile::removeBlacklistedTag(const QString &tag)
 {
 	m_blacklist.remove(tag);
+
+	syncBlacklist();
+	emit blacklistChanged();
+}
+void Profile::removeBlacklistedTags(const QStringList &tags)
+{
+	m_blacklist.remove(tags);
 
 	syncBlacklist();
 	emit blacklistChanged();

--- a/src/lib/src/models/profile.h
+++ b/src/lib/src/models/profile.h
@@ -80,6 +80,7 @@ class Profile : public QObject
 		// Blacklist management
 		void setBlacklistedTags(const Blacklist &blacklist);
 		void addBlacklistedTag(const QString &tag);
+		void addBlacklistedTags(const QStringList &tags);
 		void removeBlacklistedTag(const QString &tag);
 
 		// Source registries

--- a/src/lib/src/models/profile.h
+++ b/src/lib/src/models/profile.h
@@ -82,6 +82,7 @@ class Profile : public QObject
 		void addBlacklistedTag(const QString &tag);
 		void addBlacklistedTags(const QStringList &tags);
 		void removeBlacklistedTag(const QString &tag);
+		void removeBlacklistedTags(const QStringList &tags);
 
 		// Source registries
 		const QList<SourceRegistry*> &getSourceRegistries() const;

--- a/src/lib/tests/src/backup-test.cpp
+++ b/src/lib/tests/src/backup-test.cpp
@@ -168,6 +168,17 @@ TEST_CASE("Backup")
 		REQUIRE(!fresh->getBlacklist().contains("another_tag"));
 	}
 
+	SECTION("site-specific blacklist.txt")
+	{
+		profile->addBlacklistedTags({ "website:danbooru.donmai.us", "test_tag" });
+		REQUIRE(profile->getBlacklist().toString() == "website:danbooru.donmai.us test_tag");
+		REQUIRE(saveBackup(profile.data(), zipFile));
+
+		REQUIRE(unzipFile(zipFile, zipDir));
+		Profile after(zipDir);
+		REQUIRE(after.getBlacklist().toString() == "website:danbooru.donmai.us test_tag");
+	}
+
 	SECTION("monitors.json")
 	{
 		// Set a single setting on the profile and back it up

--- a/src/lib/tests/src/models/filtering/blacklist-test.cpp
+++ b/src/lib/tests/src/models/filtering/blacklist-test.cpp
@@ -104,4 +104,19 @@ TEST_CASE("Blacklist")
 		REQUIRE(blacklist.match(tokensWith) == QStringList("re:zero"));
 		REQUIRE(blacklist.match(tokensWithout) == QStringList());
 	}
+
+	SECTION("Site-specific tag")
+	{
+		Blacklist blacklist;
+		blacklist.add({ "website:danbooru.donmai.us", "test_tag" });
+
+		QMap<QString, Token> matchingSite;
+		matchingSite.insert("website", Token("danbooru.donmai.us"));
+		matchingSite.insert("allos", Token(QStringList() << "test_tag"));
+		QMap<QString, Token> otherSite = matchingSite;
+		otherSite.insert("website", Token("gelbooru.com"));
+
+		REQUIRE(blacklist.match(matchingSite) == QStringList("website:danbooru.donmai.us test_tag"));
+		REQUIRE(blacklist.match(otherSite) == QStringList());
+	}
 }


### PR DESCRIPTION
Hello, here is a simple modification I wanted to do since a long time. 

If you blacklist a tag, you should be able to specify the website where to balcklist it. 
So with the help of Codex I tested and added this function. You can now press "shift" to block a tag only for the website you're on. It add the "website:gelbooru.com " (or whatever site you're on" to the blacklist before the tag.)  Hence it only block a tag for this specific website.

I tested it on the last develop branch and it was fine after compilation.

Sorry if something is wrong it's my first time using Codex to male a commit.