### PR TITLE
fix: ensure open in new tab works for tags in image viewer window

### DIFF
--- a/src/gui/src/tag-context-menu.cpp
+++ b/src/gui/src/tag-context-menu.cpp
@@ -142,7 +142,7 @@ void TagContextMenu::unblacklistSite()
 
 void TagContextMenu::openInNewTab()
 {
-	emit openNewTab();
+	emit openNewTab(m_tag);
 }
 void TagContextMenu::openInNewWindow()
 {

--- a/src/gui/src/tag-context-menu.h
+++ b/src/gui/src/tag-context-menu.h
@@ -41,7 +41,7 @@ class TagContextMenu : public QMenu
 
 	signals:
 		void setFavoriteImage();
-		void openNewTab();
+		void openNewTab(const QString & = QString());
 
 	private:
 		QString m_tag;

--- a/src/gui/src/viewer/viewer-window.cpp
+++ b/src/gui/src/viewer/viewer-window.cpp
@@ -566,10 +566,11 @@ void ViewerWindow::contextMenu(const QPoint &pos)
 	menu->exec(QCursor::pos());
 }
 
-void ViewerWindow::openInNewTab()
+void ViewerWindow::openInNewTab(const QString &link)
 {
-	if (!m_link.isEmpty()) {
-		m_parent->addTab(m_link, false, true, m_tab);
+	QString activeLink = link.isEmpty() ? m_link : link;
+	if (!activeLink.isEmpty()) {
+		m_parent->addTab(activeLink, false, true, m_tab);
 	}
 }
 void ViewerWindow::setfavorite()

--- a/src/gui/src/viewer/viewer-window.h
+++ b/src/gui/src/viewer/viewer-window.h
@@ -69,7 +69,7 @@ class ViewerWindow : public QWidget
 		void openSaveDir(bool fav = false);
 		void linkHovered(const QString &);
 		void contextMenu(const QPoint &pos);
-		void openInNewTab();
+		void openInNewTab(const QString & = QString());
 		void setfavorite();
 		void downloadProgress(QSharedPointer<Image> img, qint64 bytesReceived, qint64 bytesTotal);
 		void colore();


### PR DESCRIPTION
Fixes #3667

Makes the tag context menu in viewer window pass its tag back to viewer window in order to more reliably trigger the open in new tab action with the chosen tag.