### PR TITLE
Use png only for previews on anime-pictures.net

### DIFF
--- a/src/sites/Anime pictures/model.ts
+++ b/src/sites/Anime pictures/model.ts
@@ -29,7 +29,7 @@ function completeImage(img: IImage, raw: any): IImage {
     if (!img.preview_url && !img.sample_url && !img.file_url) {
         const domain = "anime-pictures.net";
         const md5Part = img.md5?.substring(0, 3) + "/" + img.md5;
-        const previewExt = raw["have_alpha"] === true ? "png" : "jpg";
+        const previewExt = "png";
         img.preview_url = `//opreviews.${domain}/${md5Part}_sp.${previewExt}`;
         img.sample_url = `//opreviews.${domain}/${md5Part}_bp.${previewExt}`;
         img.file_url = `//oimages.${domain}/${md5Part}.${img.ext}`;


### PR DESCRIPTION
The anime-pictures.net model incorrectly assumes that previews without alpha channel use .jpg extension. In reality, the site serves all previews as PNG regardless of the original file format.

This PR:

- Removes have_alpha check for preview extension
- Always uses .png for _sp and _bp thumbnails

Before:
<img width="3282" height="1630" alt="изображение" src="https://github.com/user-attachments/assets/996a5591-2143-4afd-a71e-9a1e9fb1229d" />

After (some not so safe pics are blurred by me):
<img width="3158" height="842" alt="изображение" src="https://github.com/user-attachments/assets/cb91222f-b45c-41ed-bd75-e175cef1c393" />
