### PR TITLE
Fix scaling of favorite thumbnails (fix #3405)

### DIFF
--- a/src/gui/src/tabs/favorites-tab.cpp
+++ b/src/gui/src/tabs/favorites-tab.cpp
@@ -166,8 +166,8 @@ void FavoritesTab::updateFavorites()
 
 			QPixmap img = fav.getImage();
 			auto *image = new QBouton(fav.getName(), resizeInsteadOfCropping, false, 0, QColor(), this);
-				image->scale(img, QSize(imageSize, imageSize) / devicePixelRatio());
-				image->setFixedSize(QSize(dim, dim) / devicePixelRatio());
+				image->scale(img, QSize(imageSize, imageSize));
+				image->setFixedSize(QSize(dim, dim) / image->devicePixelRatio());
 				image->setFlat(true);
 				image->setToolTip(xt);
 				connect(image, SIGNAL(rightClick(QString)), this, SLOT(favoriteProperties(QString)));


### PR DESCRIPTION
That commit https://github.com/Bionus/imgbrd-grabber/commit/66e0949d1c4f0b4a9845711c49207f659f65c692 didn't resolve  awful scaling of #3405.

Here is another try as suggested by DeepSeek.

Screenshot from 2560x1440 monitor with 125% system scaling and 300% thumbnail scaling setting inside Grabber:
<img width="1573" height="1075" alt="Снимок экрана_20260814_195433" src="https://github.com/user-attachments/assets/f851a5da-a782-454b-b21f-8d1470cca9ae" />
