### PR TITLE
Add Russian translation to org.bionus.Grabber.desktop

### DIFF
--- a/src/dist/linux/org.bionus.Grabber.desktop
+++ b/src/dist/linux/org.bionus.Grabber.desktop
@@ -2,6 +2,7 @@
 Type=Application
 Name=Grabber
 Comment=Very customizable imageboard/booru downloader with powerful filenaming features
+Comment[ru]=Гибкий загрузчик изображений с имиджбордов и booru-сайтов с настройкой формата имён файлов
 Exec=Grabber
 Icon=grabber
 Categories=Network;


### PR DESCRIPTION
The added `Comment[ru]` entry follows the freedesktop.org Desktop Entry Specification for localized values: https://specifications.freedesktop.org/desktop-entry/1.5/localized-keys.html