### PR TITLE
Bound retries for rate-limited page requests

### DIFF
--- a/src/lib/src/custom-network-access-manager.cpp
+++ b/src/lib/src/custom-network-access-manager.cpp
@@ -30,6 +30,10 @@ QNetworkReply *CustomNetworkAccessManager::makeErrorReply(const QNetworkRequest 
 	if (code == QLatin1String("404")) {
 		reply->setHttpStatusCode(404, "Not Found");
 		reply->setNetworkError(QNetworkReply::ContentNotFoundError, QStringLiteral("Not Found"));
+	} else if (code == QLatin1String("429") || code == QLatin1String("503") || code == QLatin1String("509")) {
+		const int statusCode = code.toInt();
+		reply->setHttpStatusCode(statusCode, "Retryable error");
+		reply->setNetworkError(QNetworkReply::UnknownNetworkError, QStringLiteral("Retryable error"));
 	} else if (code == QLatin1String("cookie")) {
 		cookieJar()->insertCookie(QNetworkCookie("test_cookie", "test_value"));
 		reply->setHttpStatusCode(200, "OK");
@@ -60,7 +64,7 @@ QNetworkReply *CustomNetworkAccessManager::makeTestReply(const QNetworkRequest &
 	}
 
 	// Error testing
-	if (path == QLatin1String("404") || path == QLatin1String("500") || path == QLatin1String("cookie") || path == QLatin1String("redirect")) {
+	if (path == QLatin1String("404") || path == QLatin1String("429") || path == QLatin1String("500") || path == QLatin1String("503") || path == QLatin1String("509") || path == QLatin1String("cookie") || path == QLatin1String("redirect")) {
 		return makeErrorReply(request, path);
 	}
 

--- a/src/lib/src/models/page-api.cpp
+++ b/src/lib/src/models/page-api.cpp
@@ -122,6 +122,10 @@ void PageApi::load(bool rateLimit, bool force)
 		setReply(nullptr);
 	}
 
+	if (!rateLimit) {
+		m_rateLimitRetryCount = 0;
+	}
+
 	if (m_url.isEmpty() && !m_errors.isEmpty()) {
 		for (const QString &err : qAsConst(m_errors)) {
 			log(QStringLiteral("[%1][%2] %3").arg(m_site->url(), m_format, err), Logger::Warning);
@@ -206,7 +210,20 @@ void PageApi::parse()
 	// Detect HTTP 429 / 503 / 509 usage limit reached
 	const int statusCode = m_reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
 	if (statusCode == 429 || statusCode == 503 || statusCode == 509) {
-		log(QStringLiteral("[%1][%2] Limit reached (%3). New try.").arg(m_site->url(), m_format, QString::number(statusCode)), Logger::Warning);
+		const int maxRetries = qMax(0, m_site->setting("download/throttle_max_retries", 2).toInt());
+		if (m_rateLimitRetryCount >= maxRetries) {
+			const QString error = QStringLiteral("Rate limit reached after %1 retries (HTTP %2).").arg(m_rateLimitRetryCount).arg(statusCode);
+			m_errors.append(error);
+			log(QStringLiteral("[%1][%2] %3").arg(m_site->url(), m_format, error), Logger::Warning);
+			setReply(nullptr);
+			m_loaded = true;
+			m_loading = false;
+			emit finishedLoading(this, LoadResult::Error);
+			return;
+		}
+
+		m_rateLimitRetryCount++;
+		log(QStringLiteral("[%1][%2] Limit reached (%3). New try %4/%5.").arg(m_site->url(), m_format).arg(statusCode).arg(m_rateLimitRetryCount).arg(maxRetries), Logger::Warning);
 		load(true, true);
 		return;
 	}

--- a/src/lib/src/models/page-api.h
+++ b/src/lib/src/models/page-api.h
@@ -104,6 +104,7 @@ class PageApi : public QObject
 		QList<Tag> m_tags;
 		NetworkReply *m_reply;
 		int m_imagesCount, m_maxImagesCount, m_pagesCount, m_pageImageCount, m_filteredImageCount;
+		int m_rateLimitRetryCount = 0;
 		bool m_imagesCountSafe, m_pagesCountSafe;
 		bool m_loading = false;
 		bool m_loaded = false;

--- a/src/lib/tests/src/models/page-api-test.cpp
+++ b/src/lib/tests/src/models/page-api-test.cpp
@@ -1,5 +1,7 @@
 #include <QScopedPointer>
 #include <QSettings>
+#include <QSignalSpy>
+#include "custom-network-access-manager.h"
 #include "models/page.h"
 #include "models/page-api.h"
 #include "models/profile.h"
@@ -22,6 +24,8 @@ TEST_CASE("PageApi")
 	QSettings settings(path, QSettings::IniFormat);
 	settings.setValue("auth/pseudo", "user");
 	settings.setValue("auth/apiKey", "test-api-key");
+	settings.setValue("download/throttle_retry", 0);
+	settings.setValue("download/throttle_max_retries", 2);
 	settings.sync();
 
 	const QScopedPointer<Profile> pProfile(makeProfile());
@@ -64,5 +68,27 @@ TEST_CASE("PageApi")
 		pageApi.setLastPage(prevPage.pageInformation());
 
 		REQUIRE(pageApi.url().toString() == QString("https://danbooru.donmai.us/posts.xml?limit=25&page=b0&tags=test tag&login=user&api_key=test-api-key"));
+	}
+
+	SECTION("RateLimitRetriesAreBounded")
+	{
+		Site *site = sites.first();
+		const QString statusCode = GENERATE(QString("429"), QString("503"), QString("509"));
+		CustomNetworkAccessManager::NextFiles.enqueue(statusCode);
+		CustomNetworkAccessManager::NextFiles.enqueue(statusCode);
+		CustomNetworkAccessManager::NextFiles.enqueue(statusCode);
+
+		QStringList tags = QStringList() << "test";
+		Page page(profile, site, sites, tags);
+		PageApi pageApi(&page, profile, site, site->getApis().first(), tags);
+		QSignalSpy spy(&pageApi, SIGNAL(finishedLoading(PageApi*, PageApi::LoadResult)));
+
+		pageApi.load();
+		REQUIRE(spy.wait());
+
+		const QList<QVariant> arguments = spy.takeFirst();
+		REQUIRE(arguments.at(1).value<PageApi::LoadResult>() == PageApi::LoadResult::Error);
+		REQUIRE(pageApi.errors().contains("Rate limit reached after 2 retries (HTTP " + statusCode + ")."));
+		REQUIRE(CustomNetworkAccessManager::NextFiles.isEmpty());
 	}
 }


### PR DESCRIPTION
## What this changes

Page requests currently retry HTTP 429, 503, and 509 responses indefinitely. If a source keeps returning one of these statuses, a search can remain in a retry loop forever and keep scheduling network requests every `download/throttle_retry` interval.

This change makes those retries bounded:

- resets the retry counter for every new, non-retry page load;
- retries the same request up to `download/throttle_max_retries` times (default: `2`);
- keeps using the existing retry throttle between attempts;
- reports a `LoadResult::Error` with the HTTP status after the retry budget is exhausted;
- leaves the maximum configurable per source, including `0` to disable retries.

## Why

Persistent throttling, an unavailable upstream, or a source that incorrectly returns 503/509 should not leave Grabber loading forever. A terminal error lets the UI and download pipeline recover, gives users useful diagnostics, and avoids unbounded background traffic.

## Tests

The PageApi test suite now simulates repeated HTTP 429, 503, and 509 responses and verifies that:

- exactly two retries are performed with the default test configuration;
- loading finishes with `LoadResult::Error`;
- the error includes the retry count and final HTTP status;
- no queued retry response remains unused.

Local result (Windows, Qt 6.6 compatibility build): `PageApi` — 22 assertions passed.