### PR TITLE
Fallback to alternate preview URLs when thumbnails fail

### DIFF
--- a/src/gui/src/tabs/image-preview.cpp
+++ b/src/gui/src/tabs/image-preview.cpp
@@ -27,6 +27,16 @@
 #include "ui/QBouton.h"
 
 
+namespace
+{
+	void appendUniqueUrl(QList<QUrl> &urls, const QUrl &url)
+	{
+		if (url.isValid() && !url.isEmpty() && !urls.contains(url)) {
+			urls.append(url);
+		}
+	}
+}
+
 QMovie *ImagePreview::m_loadingMovie = nullptr;
 
 ImagePreview::ImagePreview(QSharedPointer<Image> image, QWidget *container, Profile *profile, DownloadQueue *downloadQueue, MainWindow *mainWindow, QObject *parent)
@@ -38,6 +48,14 @@ ImagePreview::ImagePreview(QSharedPointer<Image> image, QWidget *container, Prof
 		m_thumbnailUrl = image->mediaForSize(QSize(imageSize, imageSize), true).url;
 	} else {
 		m_thumbnailUrl = image->url(Image::Size::Thumbnail);
+	}
+
+	appendUniqueUrl(m_thumbnailFallbackUrls, m_thumbnailUrl);
+	appendUniqueUrl(m_thumbnailFallbackUrls, image->url(Image::Size::Thumbnail));
+	appendUniqueUrl(m_thumbnailFallbackUrls, image->url(Image::Size::Sample));
+	appendUniqueUrl(m_thumbnailFallbackUrls, image->url(Image::Size::Full));
+	if (!m_thumbnailFallbackUrls.isEmpty()) {
+		m_thumbnailUrl = m_thumbnailFallbackUrls.first();
 	}
 
 	m_name = image->name();
@@ -53,7 +71,9 @@ ImagePreview::ImagePreview(QSharedPointer<Image> image, QWidget *container, Prof
 
 ImagePreview::~ImagePreview()
 {
-	m_reply->deleteLater();
+	if (m_reply != nullptr) {
+		m_reply->deleteLater();
+	}
 	m_reply = nullptr;
 
 	// We don't own the button, but it will likely be deleted soon as well
@@ -102,7 +122,7 @@ void ImagePreview::load()
 void ImagePreview::abort()
 {
 	m_aborted = true;
-	if (m_reply->isRunning()) {
+	if (m_reply != nullptr && m_reply->isRunning()) {
 		m_reply->abort();
 	}
 }
@@ -121,6 +141,20 @@ void ImagePreview::setDownloadProgress(qint64 v1, qint64 v2)
 	if (m_bouton != nullptr) {
 		m_bouton->setProgress(v1, v2);
 	}
+}
+
+bool ImagePreview::tryNextThumbnailUrl(const QString &reason)
+{
+	while (++m_thumbnailFallbackIndex < m_thumbnailFallbackUrls.count()) {
+		m_thumbnailUrl = m_thumbnailFallbackUrls.at(m_thumbnailFallbackIndex);
+		m_triedJpegFallback = false;
+
+		log(QStringLiteral("Thumbnail failed (%1), trying fallback `%2`.").arg(reason, m_thumbnailUrl.toString()), Logger::Warning);
+		load();
+		return true;
+	}
+
+	return false;
 }
 
 
@@ -147,10 +181,15 @@ void ImagePreview::finishedLoadingPreview()
 	if (m_reply->error() != NetworkReply::NetworkError::NoError) {
 		// Retry with JPG in case the original thumbnail had a weird extension
 		const QString ext = getExtension(m_reply->url());
-		if (!ext.isEmpty() && ext != "jpg") {
+		if (!m_triedJpegFallback && !ext.isEmpty() && ext != "jpg") {
+			m_triedJpegFallback = true;
 			log(QStringLiteral("Error loading thumbnail (%1), new try with extension JPG").arg(m_reply->errorString()), Logger::Warning);
 			m_thumbnailUrl = setExtension(m_reply->url(), "jpg");
 			load();
+			return;
+		}
+
+		if (tryNextThumbnailUrl(m_reply->errorString())) {
 			return;
 		}
 
@@ -163,6 +202,10 @@ void ImagePreview::finishedLoadingPreview()
 	QPixmap thumbnail;
 	thumbnail.loadFromData(m_reply->readAll());
 	if (thumbnail.isNull()) {
+		if (tryNextThumbnailUrl(QStringLiteral("empty image data"))) {
+			return;
+		}
+
 		log(QStringLiteral("One of the thumbnails is empty (`%1`).").arg(m_reply->url().toString()), Logger::Error);
 		finishedLoading();
 		return;

--- a/src/gui/src/tabs/image-preview.h
+++ b/src/gui/src/tabs/image-preview.h
@@ -2,6 +2,7 @@
 #define IMAGE_PREVIEW_H
 
 #include <functional>
+#include <QList>
 #include <QObject>
 #include <QPixmap>
 #include <QPointer>
@@ -38,6 +39,7 @@ class ImagePreview : public QObject
 	protected:
 		void showLoadingMessage();
 		void finishedLoading();
+		bool tryNextThumbnailUrl(const QString &reason);
 
 	protected slots:
 		void finishedLoadingPreview();
@@ -65,6 +67,9 @@ class ImagePreview : public QObject
 		bool m_checked = false;
 
 		QUrl m_thumbnailUrl;
+		QList<QUrl> m_thumbnailFallbackUrls;
+		int m_thumbnailFallbackIndex = 0;
+		bool m_triedJpegFallback = false;
 		QString m_name;
 		QString m_counter;
 		QPointer<QBouton> m_bouton = nullptr;


### PR DESCRIPTION
## What this changes

A parsed image can expose several usable preview URLs (the smart-size result, thumbnail, sample, and full image), but the GUI currently gives up after the selected URL fails (apart from the existing extension-to-JPG retry). This leaves a `noimage` tile even when another parsed URL would load correctly.

This change builds an ordered, de-duplicated fallback list for every result:

1. the URL selected by the existing smart-size logic;
2. the explicit thumbnail URL;
3. the sample URL;
4. the full image URL.

On a network error, Grabber keeps the existing one-time JPG-extension retry and then advances through the remaining candidates. It also advances when a response succeeds at the HTTP level but cannot be decoded into a pixmap, which covers empty bodies and HTML/error payloads returned with status 200.

## Why

Sources and CDNs do not fail uniformly: thumbnail hosts can be unavailable while samples still work, a parser may temporarily return a stale thumbnail URL, and some endpoints return an empty or non-image body without a network error. Trying the image URLs already present in the parsed result avoids unnecessary blank tiles and makes merged-source grids more resilient.

This is intentionally conservative:

- duplicate and invalid URLs are skipped;
- the full image is only requested after smaller alternatives fail;
- the JPG rewrite is attempted at most once per candidate, preventing retry cycles;
- a result is **not hidden** if every candidate fails, so users can still open its page or use its context menu;
- null checks make abort/destruction safe for results that never created a network reply.

This addresses the failure pattern discussed in #1039 without changing grid layout or result visibility.

## Verification

- `image-preview.cpp` compiles successfully on Windows with Qt 6.6 compatibility settings.
- The implementation is based on current `develop` and preserves the existing video overlay, loading indicator, smart-size selection, redirection handling, and JPG fallback behavior.