### PR TITLE
Make the main tab bar responsive and safer

### DIFF
--- a/src/gui/src/ui/qclosabletabwidget.cpp
+++ b/src/gui/src/ui/qclosabletabwidget.cpp
@@ -1,12 +1,64 @@
 #include "ui/qclosabletabwidget.h"
 #include <QMouseEvent>
+#include <QResizeEvent>
 #include <QTabBar>
+#include <QTabWidget>
+#include <QtMath>
 #include "tabs/search-tab.h"
+
+
+namespace
+{
+	class ResponsiveTabBar : public QTabBar
+	{
+		public:
+			explicit ResponsiveTabBar(QWidget *parent = nullptr)
+				: QTabBar(parent)
+			{
+				setElideMode(Qt::ElideRight);
+				setExpanding(false);
+				setUsesScrollButtons(true);
+			}
+
+			QSize tabSizeHint(int index) const override
+			{
+				QSize size = QTabBar::tabSizeHint(index);
+				constexpr int minWidth = 72;
+				constexpr int maxWidth = 200;
+				int availableWidth = parentWidget() != nullptr ? parentWidget()->width() : width();
+				if (const auto *tabs = qobject_cast<const QTabWidget*>(parentWidget())) {
+					for (Qt::Corner corner : { Qt::TopLeftCorner, Qt::TopRightCorner }) {
+						const QWidget *cornerWidget = tabs->cornerWidget(corner);
+						if (cornerWidget != nullptr && cornerWidget->isVisible()) {
+							availableWidth -= cornerWidget->width();
+						}
+					}
+				}
+
+				if (availableWidth > 0 && count() > 0) {
+					size.setWidth(qBound(minWidth, availableWidth / count(), maxWidth));
+				} else {
+					size.setWidth(qMin(size.width(), maxWidth));
+				}
+
+				return size;
+			}
+
+		protected:
+			void resizeEvent(QResizeEvent *event) override
+			{
+				QTabBar::resizeEvent(event);
+				updateGeometry();
+				update();
+			}
+	};
+}
 
 
 QClosableTabWidget::QClosableTabWidget(QWidget *parent)
 	: QTabWidget(parent)
 {
+	setTabBar(new ResponsiveTabBar(this));
 	tabBar()->installEventFilter(this);
 }
 
@@ -16,13 +68,16 @@ bool QClosableTabWidget::eventFilter(QObject *o, QEvent *e)
 		auto *mouseEvent = dynamic_cast<QMouseEvent*>(e);
 		if (mouseEvent != nullptr && mouseEvent->button() == Qt::MiddleButton) {
 			const int index = tabBar()->tabAt(mouseEvent->pos());
+			if (index < 0) {
+				return false;
+			}
+
 			QWidget *w = widget(index);
 			SearchTab *tab = dynamic_cast<SearchTab*>(w);
+			const bool hasCloseButton = tabBar()->tabButton(index, QTabBar::LeftSide) != nullptr || tabBar()->tabButton(index, QTabBar::RightSide) != nullptr;
 
-			// Non-closable tabs have a maximum width of 16777214 (default: 16777215)
-			if (tab != nullptr && !tab->isLocked() && w->maximumWidth() != 16777214) {
+			if (tab != nullptr && !tab->isLocked() && hasCloseButton) {
 				w->close();
-				removeTab(index);
 				return true;
 			}
 		}

--- a/src/gui/tests/qclosabletabwidget-test.cpp
+++ b/src/gui/tests/qclosabletabwidget-test.cpp
@@ -1,0 +1,33 @@
+#include <QApplication>
+#include <QTabBar>
+#include <QWidget>
+#include "catch.h"
+#include "ui/qclosabletabwidget.h"
+
+
+TEST_CASE("QClosableTabWidget")
+{
+	QClosableTabWidget tabWidget(nullptr);
+	tabWidget.resize(700, 300);
+	for (int i = 0; i < 3; ++i) {
+		tabWidget.addTab(new QWidget(&tabWidget), QStringLiteral("A long tab title %1").arg(i));
+	}
+
+	tabWidget.show();
+	QApplication::processEvents();
+
+	auto *tabBar = tabWidget.findChild<QTabBar*>();
+	REQUIRE(tabBar != nullptr);
+	REQUIRE(tabBar->elideMode() == Qt::ElideRight);
+	REQUIRE(tabBar->usesScrollButtons());
+
+	const int wideTabWidth = tabBar->tabRect(0).width();
+	REQUIRE(wideTabWidth <= 200);
+
+	tabWidget.resize(300, 300);
+	QApplication::processEvents();
+	const int narrowTabWidth = tabBar->tabRect(0).width();
+
+	REQUIRE(narrowTabWidth >= 72);
+	REQUIRE(narrowTabWidth < wideTabWidth);
+}


### PR DESCRIPTION
## What this changes

The main tab bar now adapts to the available window width instead of letting long labels and the corner controls crowd or clip the last tabs.

- Tab widths are distributed from the actual `QTabWidget` width, with visible corner widgets subtracted.
- Each tab stays between 72 and 200 pixels.
- Long titles are elided on the right.
- Scroll buttons remain available once the tabs cannot shrink any further.
- Existing corner controls, custom close buttons, locked search tabs, and the tab selector remain intact.

## Safer middle-click closing

This also removes two fragile assumptions from the existing middle-click handler:

- A click outside any tab is ignored instead of attempting to resolve tab `-1`.
- A tab is considered closable when it has an actual close button, rather than by comparing a widget width to the magic value `16777214`.
- The handler calls the tab's existing `close()` lifecycle only. It no longer immediately calls `removeTab()` as a second, competing removal path.

## Why

With several tabs or longer translated labels, the previous tab bar could consume more space than the window header had available. The rightmost tabs and the `+` corner button could then appear clipped or misaligned, especially in narrow windows. The adaptive bounds keep the header usable at both wide and compact sizes.

## Test coverage

Added a GUI test that creates three long-titled tabs and verifies:

- right-side elision is enabled;
- scroll buttons are enabled;
- wide tabs do not exceed 200 px;
- narrow tabs do not fall below 72 px;
- resizing the widget from 700 px to 300 px actually reduces tab width.

Local result (Windows, Qt 6.6.3): all 6 assertions passed.

## Screenshot

Seven search tabs in a narrow window: labels elide, overflow arrows remain reachable, and the new-tab button keeps its place.

<img width="550" height="125" alt="Responsive search tabs at narrow width" src="https://github.com/user-attachments/assets/d182a95c-a79a-4509-ba89-aca30566e30a" />

