### PR TITLE
Handle empty and failed QML image previews

### DIFF
--- a/src/gui-qml/src/async-image-response.cpp
+++ b/src/gui-qml/src/async-image-response.cpp
@@ -2,12 +2,20 @@
 #include <QImage>
 #include <QNetworkReply>
 #include <QQuickTextureFactory>
+#include <QTimer>
 
 
 AsyncImageResponse::AsyncImageResponse(QNetworkReply *reply, const QRect &rect)
 	: m_reply(reply), m_rect(rect)
 {
-	connect(m_reply, &QNetworkReply::finished, this, &AsyncImageResponse::replyFinished);
+	if (m_reply != nullptr) {
+		connect(m_reply, &QNetworkReply::finished, this, &AsyncImageResponse::replyFinished);
+	} else {
+		m_error = tr("Empty image URL");
+		QTimer::singleShot(0, this, [this]() {
+			emit finished();
+		});
+	}
 }
 
 QQuickTextureFactory *AsyncImageResponse::textureFactory() const
@@ -15,16 +23,28 @@ QQuickTextureFactory *AsyncImageResponse::textureFactory() const
 	return m_texture;
 }
 
+QString AsyncImageResponse::errorString() const
+{
+	return m_error;
+}
+
 void AsyncImageResponse::replyFinished()
 {
+	QImage thumbnail;
 	if (m_reply->error() == QNetworkReply::NoError) {
-		QImage thumbnail;
 		thumbnail.loadFromData(m_reply->readAll());
 
-		if (!m_rect.isNull() && !m_rect.isEmpty()) {
+		if (!thumbnail.isNull() && !m_rect.isNull() && !m_rect.isEmpty()) {
 			thumbnail = thumbnail.copy(m_rect);
 		}
-
+	} else {
+		m_error = m_reply->errorString();
+	}
+	if (thumbnail.isNull()) {
+		if (m_error.isEmpty()) {
+			m_error = tr("Invalid image data");
+		}
+	} else {
 		m_texture = QQuickTextureFactory::textureFactoryForImage(thumbnail);
 	}
 

--- a/src/gui-qml/src/async-image-response.h
+++ b/src/gui-qml/src/async-image-response.h
@@ -13,6 +13,7 @@ class AsyncImageResponse : public QQuickImageResponse
 	public:
 		explicit AsyncImageResponse(QNetworkReply *reply, const QRect &rect);
 		QQuickTextureFactory *textureFactory() const override;
+		QString errorString() const override;
 
 	protected slots:
 		void replyFinished();
@@ -21,6 +22,7 @@ class AsyncImageResponse : public QQuickImageResponse
 		QNetworkReply *m_reply;
 		QRect m_rect;
 		QQuickTextureFactory *m_texture = nullptr;
+		QString m_error;
 };
 
 #endif // ASYNC_IMAGE_RESPONSE_H

--- a/src/gui-qml/src/components/ResultsView.qml
+++ b/src/gui-qml/src/components/ResultsView.qml
@@ -63,7 +63,32 @@ ScrollView {
             onColumnsChanged: resultsRefresher.restart()
 
             delegate: Item {
+                readonly property real safeRatio: img.status === Image.Ready
+                    && img.implicitWidth > 0
+                    && img.implicitHeight > 0
+                        ? img.implicitHeight / img.implicitWidth
+                        : 1
+
                 height: img.height + root.thumbnailSpacing
+
+                Rectangle {
+                    anchors.centerIn: parent
+                    width: parent.width - root.thumbnailSpacing
+                    height: img.height
+                    radius: root.thumbnailRadius
+                    color: "transparent"
+                    border.color: Material.hintTextColor
+                    border.width: 1
+                    visible: img.status === Image.Error
+
+                    Text {
+                        anchors.centerIn: parent
+                        text: "!"
+                        color: Material.secondaryTextColor
+                        font.pixelSize: Math.max(18, parent.width * 0.18)
+                        font.bold: true
+                    }
+                }
 
                 Image {
                     id: img
@@ -72,8 +97,9 @@ ScrollView {
                     anchors.centerIn: parent
                     width: parent.width - root.thumbnailSpacing
                     height: root.thumbnailHeightToWidthRatio < 0.1
-                        ? img.width * (img.implicitHeight / img.implicitWidth)
+                        ? img.width * parent.safeRatio
                         : img.width * root.thumbnailHeightToWidthRatio
+                    visible: status !== Image.Error
 
                     onHeightChanged: resultsRefresher.restart()
 


### PR DESCRIPTION
## What this fixes

The asynchronous QML image provider deliberately constructs `AsyncImageResponse(nullptr, {})` when an image has no preview URL. The response currently calls `connect()` with that null reply, never produces a result, and never emits `finished()`. This can leave the corresponding QML image request pending indefinitely.

Network failures and successful HTTP responses containing empty or undecodable image data have a related problem: the response emits `finished()` without exposing why no texture exists. The masonry layout also divides by an implicit image width that is zero until loading succeeds, which can produce invalid item heights and visible holes in the result grid.

## New behavior

- A response created without a `QNetworkReply` records `Empty image URL` and emits `finished()` on the next event-loop turn.
- Network failures preserve the reply's error text.
- Empty, unsupported, corrupt, or invalidly cropped image data reports `Invalid image data`.
- Preview cropping is attempted only after bytes decode into a valid image.
- `errorString()` lets Qt put the QML `Image` into `Image.Error` rather than leaving it pending or silently transparent.
- The result delegate uses a safe 1:1 ratio while dimensions are unavailable, avoiding division by zero.
- Failed previews render a small theme-aware placeholder with a border and `!`, while the result remains clickable.
- Valid images keep their existing behavior, fill mode, badges, video overlay, and rounded mask.

The queued completion for the null-reply case is intentional: it gives the caller time to connect to the `finished()` signal before the response completes.

## Why

Sparse source results should appear as an explicit failed preview, not alternate between images and unexplained empty cells. Completing every request also prevents the QML gallery from retaining permanently pending image jobs.

## Verification

Built the full `gui-qml` target successfully on Windows with Qt 6.6.3. The project does not currently expose a dedicated gui-qml unit-test target, so the C++ lifecycle change and QML fallback are kept together in one focused PR.