### PR TITLE
Decode HTML entities in image and gallery names

### DIFF
--- a/src/lib/src/models/image.cpp
+++ b/src/lib/src/models/image.cpp
@@ -106,7 +106,7 @@ Image::Image(Site *site, QMap<QString, QString> details, QVariantMap identity, Q
 	// Other details
 	m_isGallery = details.contains("type") && details["type"] == "gallery";
 	m_md5 = details.contains("md5") ? details["md5"] : "";
-	m_name = details.contains("name") ? details["name"] : "";
+	m_name = details.contains("name") ? decodeHtmlEntities(details["name"]) : "";
 	m_search = parent != nullptr ? parent->search() : (details.contains("search") ? details["search"].split(' ') : QStringList());
 	m_id = details.contains("id") ? details["id"].toULongLong() : 0;
 	m_sources = details.contains("sources") ? details["sources"].split('\n') : (details.contains("source") ? QStringList { details["source"] } : QStringList());
@@ -417,7 +417,7 @@ bool Image::read(const QJsonObject &json, const QMap<QString, Site*> &sites)
 	}
 
 	// Basic fields
-	m_name = json["name"].toString();
+	m_name = decodeHtmlEntities(json["name"].toString());
 	m_id = json["id"].toString().toULongLong();
 	m_md5 = json["md5"].toString();
 

--- a/src/lib/tests/src/models/image-test.cpp
+++ b/src/lib/tests/src/models/image-test.cpp
@@ -110,6 +110,21 @@ TEST_CASE("Image")
 		REQUIRE(clone.parentUrl() == img->parentUrl());
 	}
 
+	SECTION("HTML-encoded name")
+	{
+		details["name"] = "Tom&#x20;&amp;&#x20;Jerry";
+		img = ImageFactory::build(site, details, profile);
+		REQUIRE(img->name() == QString("Tom & Jerry"));
+
+		QJsonObject json;
+		img->write(json);
+		json["name"] = "Rock&#x20;&amp;&#x20;Roll";
+
+		Image restored(profile);
+		REQUIRE(restored.read(json, profile->getSites()));
+		REQUIRE(restored.name() == QString("Rock & Roll"));
+	}
+
 	SECTION("HasTag")
 	{
 		REQUIRE(img->hasTag("tag1"));


### PR DESCRIPTION
## What this fixes

Some source adapters return image or gallery names containing HTML entities, for example:

- `Tom&#x20;&amp;&#x20;Jerry`
- `Rock &amp; Roll`

Tags already pass through the project's shared `decodeHtmlEntities()` helper, but image names did not. As a result, encoded punctuation and numeric whitespace entities could be displayed literally in tabs, tooltips, details, gallery labels, and filename tokens.

## New behavior

Image names are decoded at both model entry points:

1. when an `Image` is built from parsed source details;
2. when an `Image` is restored from serialized JSON/history.

The change only decodes entities. It deliberately does not trim or collapse whitespace, so source-provided title formatting is preserved.

## Compatibility

Plain names are unchanged. Existing JSON remains compatible; encoded names are normalized while reading, and subsequent serialization stores the decoded value.

## Test coverage

Extended the existing `Image` test to cover both construction and JSON restoration using numeric and named entities.

Local result (Windows, Qt 6.6.3): all 80 assertions in the `Image` test passed.