### PR TITLE
Use the active palette for search suggestion links

### DIFF
--- a/src/gui/src/tabs/search-tab.cpp
+++ b/src/gui/src/tabs/search-tab.cpp
@@ -4,6 +4,7 @@
 #include <QMenu>
 #include <QMessageBox>
 #include <QMouseEvent>
+#include <QPalette>
 #include <QSet>
 #include <QShortcut>
 #include <QtMath>
@@ -252,7 +253,9 @@ QStringList SearchTab::reasonsToFail(Page *page, const QStringList &completion, 
 
 		if (c > 0) {
 			QStringList res = results.values(), cl = clean.values();
-			*meant = QString(R"(<a href="%1" style="color:black;text-decoration:none;">%2</a>)").arg(cl.join(" ").toHtmlEscaped(), res.join(" "));
+			const QString linkColor = palette().color(QPalette::Link).name(QColor::HexRgb);
+			*meant = QString(R"(<a href="%1" style="color:%3;text-decoration:none;">%2</a>)")
+				.arg(cl.join(" ").toHtmlEscaped(), res.join(" ").toHtmlEscaped(), linkColor);
 		}
 	}
 


### PR DESCRIPTION
## Summary

- use the active Qt palette for the clickable search suggestion instead of forcing black text
- keep the link readable in dark, light, and custom themes
- HTML-escape the visible suggested tags as well as the link target

## Problem

`SearchTab::reasonsToFail()` builds the “did you mean” suggestion as rich text with an inline `color:black`. On dark themes this produces black text on a black or near-black background, making the recovery action effectively invisible.

The suggested tag names are source-derived text. The URL target was escaped already, but the visible text was inserted as raw rich text and could be interpreted as markup.

## Implementation

The link color now comes from `QPalette::Link` on the active widget palette and is serialized as an explicit RGB value for the existing inline rich-text fragment. This follows whichever palette the application or selected theme supplies.

The visible suggestion text is passed through `toHtmlEscaped()` before insertion.

## Validation

Built the complete `gui` target successfully on Windows with Qt 6.6.3.

This is intentionally separate from any new optional stylesheet: it fixes the underlying theme compatibility issue for all palettes.