### PR TITLE
Update Kemono to the current API and gallery format

### DIFF
--- a/src/sites/Kemono/model.spec.ts
+++ b/src/sites/Kemono/model.spec.ts
@@ -1,0 +1,94 @@
+import { makeGrabber, search } from "../test-utils";
+import { source } from "./model";
+
+const post = {
+    id: "post-1",
+    user: "123",
+    service: "patreon",
+    title: "Example post",
+    published: "2026-08-30T12:00:00",
+    file: { name: "main.png", path: "/aa/bb/main.png" },
+    attachments: [
+        { name: "second.jpg", path: "/cc/dd/second.jpg" },
+    ],
+};
+
+describe("Kemono", () => {
+    beforeAll(makeGrabber);
+
+    describe("JSON API", () => {
+        it("uses the current recent-posts endpoint and required header", () => {
+            expect(search(source.apis.json, "landscape", 2)).toEqual({
+                url: "/api/v1/posts?o=50&q=landscape",
+                headers: { "Accept": "text/css" },
+            });
+        });
+
+        it("supports creator searches without passing the user token as a query", () => {
+            expect(search(source.apis.json, "user:patreon:123 blue sky", 2)).toEqual({
+                url: "/api/v1/patreon/user/123/posts?o=50&q=blue%20sky",
+                headers: { "Accept": "text/css" },
+            });
+        });
+
+        it("parses wrapped recent posts and counts the main file", () => {
+            const result = source.apis.json.search.parse(JSON.stringify({ posts: [post] }), 200) as IParsedSearch;
+
+            expect(result.images).toHaveLength(1);
+            expect(result.images[0]).toMatchObject({
+                id: "post-1",
+                type: "gallery",
+                gallery_count: 2,
+                file_url: "/data/aa/bb/main.png",
+                preview_url: "/thumbnail/data/aa/bb/main.png",
+                page_url: "/patreon/user/123/post/post-1",
+                created_at: "2026-08-30T12:00:00",
+            });
+        });
+
+        it("parses creator post arrays", () => {
+            const result = source.apis.json.search.parse(JSON.stringify([post]), 200) as IParsedSearch;
+            expect(result.images).toHaveLength(1);
+        });
+
+        it("loads both the main file and attachments from gallery details", () => {
+            const request = source.apis.json.gallery!.url({
+                id: "post-1",
+                md5: "",
+                page: 1,
+                identity: { service: "patreon", user: "123", id: "post-1" },
+            }, {
+                page: 1,
+                limit: 50,
+                loggedIn: false,
+                baseUrl: "/",
+            });
+            expect(request).toEqual({
+                url: "/api/v1/patreon/user/123/post/post-1",
+                headers: { "Accept": "text/css" },
+            });
+
+            const result = source.apis.json.gallery!.parse(JSON.stringify({
+                post,
+                attachments: [post.file],
+                previews: [{ path: "/ee/ff/main-preview.png" }],
+            }), 200) as IParsedGallery;
+
+            expect(result.imageCount).toBe(2);
+            expect(result.images.map((image) => image.file_url)).toEqual([
+                "/data/aa/bb/main.png",
+                "/data/cc/dd/second.jpg",
+            ]);
+            expect(result.images.map((image) => image.name)).toEqual(["main.png", "second.jpg"]);
+            expect(result.images.map((image) => image.preview_url)).toEqual([
+                "/data/ee/ff/main-preview.png",
+                "/thumbnail/data/cc/dd/second.jpg",
+            ]);
+        });
+
+        it("reports API errors instead of treating them as empty results", () => {
+            expect(source.apis.json.search.parse('{"error":"Not Found"}', 404)).toEqual({ error: "Not Found" });
+            expect(source.apis.json.gallery!.parse('{"error":"Not Found"}', 404)).toEqual({ error: "Not Found" });
+        });
+    });
+});

--- a/src/sites/Kemono/model.ts
+++ b/src/sites/Kemono/model.ts
@@ -5,32 +5,73 @@ const map = {
     "file_url": "file.path",
     "created_at": "added",
 };
+
+const apiHeaders = {
+    "Accept": "text/css",
+};
+const apiPageSize = 50;
+const userRegex = /(?:^|\s)user:([a-z0-9_-]+):(\d+)(?=\s|$)/i;
+
+function apiRequest(url: string): IRequest {
+    return { url, headers: apiHeaders };
+}
+
+function postFiles(data: any): any[] {
+    const files: any[] = [];
+    const paths: Record<string, boolean> = {};
+    const add = (file: any): void => {
+        const path = file && file["path"];
+        if (path && !paths[path]) {
+            paths[path] = true;
+            files.push(file);
+        }
+    };
+
+    add(data && data["file"]);
+    for (const attachment of (data && data["attachments"]) || []) {
+        add(attachment);
+    }
+    return files;
+}
+
 function parseJsonImage(data: any): IImage {
     const img: IImage = Grabber.mapFields(data, map);
     img.identity = {
         service: data["service"],
         user: data["user"],
         id: data["id"],
-    }
-    if (data["attachments"].length > 1) {
+    };
+    img.page_url = `/${data["service"]}/user/${data["user"]}/post/${data["id"]}`;
+    img.created_at = data["published"] || data["added"];
+
+    const files = postFiles(data);
+    if (files.length > 1) {
         img.type = "gallery";
-        img.gallery_count = data["attachments"].length;
+        img.gallery_count = files.length;
     }
     return img;
 }
 
+function dataUrl(url: string): string {
+    if (url.indexOf('/data/') === -1 && url.substr(0, 4) !== 'http' && url[0] === '/') {
+        return '/data' + url;
+    }
+    return url;
+}
+
 function completeImage(img: IImage): IImage {
     if (img.file_url) {
-        if (img.file_url.indexOf('/data/') === -1 && img.file_url.substr(0, 4) !== 'http' && img.file_url[0] === '/') {
-            img.file_url = '/data' + img.file_url;
-        }
-        img.preview_url = img.file_url.replace('/data/', '/thumbnail/data/');
+        img.file_url = dataUrl(img.file_url);
+        img.preview_url = img.preview_url
+            ? dataUrl(img.preview_url)
+            : img.file_url.replace('/data/', '/thumbnail/data/');
     }
     return img;
 }
 
 export const source: ISource = {
     name: "Kemono",
+    modifiers: ["user:"],
     auth: {
         session: {
             type: "post",
@@ -56,41 +97,73 @@ export const source: ISource = {
         json: {
             name: "JSON",
             auth: [],
-            maxLimit: 50,
+            forcedLimit: apiPageSize,
             search: {
-                url: (query: ISearchQuery, opts: IUrlOptions): string | IError => {
-                    const offset = (query.page - 1) * opts.limit;
-                    if (query.search) {
-                        return {error: "The JSON API does not support arbitrary search."};
+                url: (query: ISearchQuery): IRequest => {
+                    const offset = (query.page - 1) * apiPageSize;
+                    const user = query.search.match(userRegex);
+                    const search = query.search.replace(userRegex, " ").trim();
+                    if (user) {
+                        return apiRequest(`/api/v1/${user[1]}/user/${user[2]}/posts?o=${offset}&q=${encodeURIComponent(search)}`);
                     }
-                    return "/api/recent?limit=" + opts.limit + "&o=" + offset; // + "&q=" + encodeURIComponent(query.search);
+                    return apiRequest(`/api/v1/posts?o=${offset}&q=${encodeURIComponent(search)}`);
                 },
                 parse: (src: string): IParsedSearch | IError => {
                     const data = JSON.parse(src);
-                    const images: IImage[] = data.map((img: any) => completeImage(parseJsonImage(img)));
+                    if (data && data["error"]) {
+                        return { error: data["error"] };
+                    }
+
+                    const posts = Array.isArray(data) ? data : data && data["posts"];
+                    if (!Array.isArray(posts)) {
+                        return { error: "Invalid Kemono API response (no posts found)" };
+                    }
+
+                    const images: IImage[] = posts.map((img: any) => completeImage(parseJsonImage(img)));
                     return { images };
                 },
             },
             gallery: {
-                url: (query: IGalleryQuery): string => {
+                url: (query: IGalleryQuery): IRequest => {
                     const identity = query.identity!;
-                    return `/api/${identity["service"]}/user/${identity["user"]}/post/${identity["id"]}`;
+                    return apiRequest(`/api/v1/${identity["service"]}/user/${identity["user"]}/post/${identity["id"]}`);
                 },
-                parse: (src: string): IParsedGallery => {
-                    const data = JSON.parse(src)[0];
-                    const image = parseJsonImage(data);
+                parse: (src: string): IParsedGallery | IError => {
+                    const data = JSON.parse(src);
+                    if (data && data["error"]) {
+                        return { error: data["error"] };
+                    }
 
-                    // Duplicate the root data for each attachment
-                    const images: IImage[] = data["attachments"].map((attachment: any) => completeImage({
-                        ...image,
-                        file_url: attachment["path"],
-                        type: "image",
-                        gallery_count: undefined,
-                    }));
+                    const post = data && (data["post"] || (Array.isArray(data) ? data[0] : data));
+                    if (!post) {
+                        return { error: "Invalid Kemono API response (no post found)" };
+                    }
+
+                    // The main file and post attachments are separate in API v1.3.
+                    // The top-level `attachments` array instead describes files
+                    // which have generated previews, so it must not replace the
+                    // post's own attachments.
+                    const image = parseJsonImage(post);
+                    const files = postFiles(post);
+                    const previewFiles = data["attachments"] || [];
+                    const previews = data["previews"] || [];
+
+                    const images: IImage[] = files.map((file: any) => {
+                        const previewIndex = previewFiles.findIndex((previewFile: any) =>
+                            previewFile["path"] === file["path"] || previewFile["name"] === file["name"]);
+                        return completeImage({
+                            ...image,
+                            file_url: file["path"],
+                            preview_url: previewIndex >= 0 && previews[previewIndex] ? previews[previewIndex]["path"] : undefined,
+                            name: file["name"] || image.name,
+                            type: "image",
+                            gallery_count: undefined,
+                        });
+                    });
 
                     return {
                         images,
-                        imageCount: data["attachments"].length,
+                        imageCount: images.length,
                         pageCount: 1,
                     };
                 },
@@ -106,11 +179,11 @@ export const source: ISource = {
                 },
             },*/
             check: {
-                url: (): string => {
-                    return "/";
+                url: (): IRequest => {
+                    return apiRequest("/");
                 },
                 parse: (src: string): boolean => {
-                    return src.indexOf("https://github.com/OpenYiff") !== -1;
+                    return /<title>\s*Kemono\s*<\/title>/i.test(src);
                 },
             },
         },


### PR DESCRIPTION
## Summary

Update the Kemono source from the retired API routes to the current v1.3 response format, restore search, and parse galleries without dropping the main post file or ordinary attachments.

Fixes #3596.

## API changes

- /api/recent → /api/v1/posts
- creator listing → /api/v1/{service}/user/{creator_id}/posts
- gallery details → /api/v1/{service}/user/{creator_id}/post/{post_id}
- send the currently required Accept: text/css header on API/check requests
- handle the wrapped { posts: [...] } recent-post response and the array returned by creator listings
- recognize the current <title>Kemono</title> marker instead of the removed OpenYiff footer

The JSON endpoint has a fixed page size of 50, so the source now declares forcedLimit: 50. This keeps offsets aligned even when the user's general images-per-page preference differs.

## Creator search

A creator can be selected with 'user:<service>:<creator-id> optional query'.

For example, 'user:patreon:123 blue sky' requests the creator-post endpoint and sends only 'blue sky' as the q parameter.

The service segment is restricted to the identifier characters used by Kemono routes, and the creator ID must be numeric.

## Gallery parsing

Kemono v1.3 separates:

1. post.file — the main post file
2. post.attachments — the actual additional downloads
3. top-level attachments + previews — metadata describing files that have generated previews

The previous implementation only iterated an attachment array and omitted the main file. A direct adaptation of the top-level array would also silently omit ordinary post attachments.

This change builds the gallery from post.file plus post.attachments, de-duplicates identical paths, and only uses the top-level arrays to associate an explicit generated preview with the matching file. Other files retain the existing derived thumbnail URL. File names, post URL, identity, and published date are preserved.

API error objects are returned as source errors instead of being rendered as empty searches.

## Validation

Automated:

- 6 focused Jest tests for recent search, creator search, wrapped/array responses, gallery composition, generated previews, and API errors
- TypeScript build passes
- focused TSLint passes

Live API validation on 2026-08-31:

- recent search: HTTP 200, 50 parsed posts
- selected gallery details: HTTP 200
- search declared 2 files and gallery parsing returned 2 files
- every returned gallery entry had both a file URL and preview URL

The request paths and header were also cross-checked against Kemono's current API documentation and gallery-dl's maintained Kemono v1.3 adapter.