### PR TITLE
Identify and throttle Zerochan API requests

### DIFF
--- a/src/sites/Zerochan/www.zerochan.net/defaults.ini
+++ b/src/sites/Zerochan/www.zerochan.net/defaults.ini
@@ -3,12 +3,18 @@ name=Zerochan
 ssl=true
 
 [download]
-throttle_retry=3
+throttle_page=2
+throttle_details=2
+throttle_retry=60
 simultaneous=1
+
+[Headers]
+User-Agent="Grabber/%version% - User/%userAgentID%"
+Accept-Language="en-US,en;q=0.9"
 
 [sources]
 usedefault=false
 source_1=rss
-source_2=regex
+source_2=
 source_3=
 source_4=


### PR DESCRIPTION
## Summary

Make the default Zerochan source identify itself, respect the site's API cadence, and stop falling back to the currently non-parsing HTML adapter.

Fixes #3441.
Fixes #3528.

## Cause

Zerochan's API documentation requires a User-Agent containing the project name and a user identity, and documents a limit of 60 API requests per minute.

The current source inherits Grabber's generic browser User-Agent. Zerochan currently rejects that request with HTTP 503. The retry delay is only 3 seconds, so the fallback HTML adapter immediately adds another request; its current parser returns zero cards even when the page itself loads.

## Changes

- send Grabber/%version% - User/%userAgentID%
  - includes an explicit project/version
  - uses Grabber's existing stable per-site installation identifier
  - remains editable in source settings for users who want to put their Zerochan username there
- send an ordinary English Accept-Language preference
- space list and details requests by two seconds
- restore the retry wait to 60 seconds
- keep one simultaneous request
- use RSS as the sole default adapter until the HTML parser is updated against the current page markup

This does not hard-code a browser build number or a contributor's username.

## Live validation (2026-08-31)

Using the current Zerochan endpoints:

| Request identity | RSS | HTML page |
| --- | ---: | ---: |
| generic Firefox UA | HTTP 503 | HTTP 503 |
| Grabber + stable user ID | HTTP 200 | HTTP 200 |

The identified RSS response contained 100 entries and the existing Grabber RSS parser returned all 100 with preview URLs.

The identified HTML response loaded, but the current regex adapter returned zero images. Disabling that fallback avoids a misleading empty result and an unnecessary extra request against the same rate limit.

Reference: Zerochan's official API page documents both the identifying User-Agent requirement and 60 requests/minute limit.