### PR TITLE
Add Wallpaper Abyss as a source

### DIFF
--- a/src/sites/Alpha Coders/model.spec.ts
+++ b/src/sites/Alpha Coders/model.spec.ts
@@ -1,0 +1,72 @@
+import { makeGrabber, search } from "../test-utils";
+import { source } from "./model";
+
+const resultCard = `
+<div id="content_123">
+    <meta content="https://images.example/123.jpeg" itemprop="contentUrl">
+    <meta itemprop="url" content="https://wall.alphacoders.com/big.php?i=123&amp;lang=en">
+    <meta itemprop="thumbnailUrl" content="https://images.example/thumb-123.webp">
+    <meta itemprop="name" content="Night &amp; Sky">
+    <meta itemprop="keywords" content="Night, Blue Sky, Stars">
+    <meta itemprop="datePublished" content="2026-08-30">
+    <span>(3840x2160)</span>
+</div>`;
+
+describe("Wallpaper Abyss", () => {
+    beforeAll(() => {
+        makeGrabber();
+        Grabber.htmlDecode = (text: string): string => text.replace(/&amp;/g, "&");
+    });
+
+    it("builds featured and text search URLs", () => {
+        expect(search(source.apis.html, "", 2)).toBe("/featured.php?page=2");
+        expect(search(source.apis.html, "blue sky", 2)).toBe("/search.php?search=blue%20sky&page=2");
+    });
+
+    it("parses result cards and HTML entities", () => {
+        const parsed = source.apis.html.search.parse(`[16,200+]${resultCard}`, 200) as IParsedSearch;
+
+        expect(parsed.imageCount).toBe(16200);
+        expect(parsed.images).toHaveLength(1);
+        expect(parsed.images[0]).toMatchObject({
+            id: "123",
+            name: "Night & Sky",
+            page_url: "https://wall.alphacoders.com/big.php?i=123&lang=en",
+            file_url: "https://images.example/123.jpeg",
+            preview_url: "https://images.example/thumb-123.webp",
+            width: 3840,
+            height: 2160,
+            ext: "jpeg",
+            rating: "safe",
+            created_at: "2026-08-30",
+            tags: ["Night", "Blue Sky", "Stars"],
+        });
+    });
+
+    it("ignores incomplete cards instead of creating blank results", () => {
+        const parsed = source.apis.html.search.parse(`${resultCard}<div id="content_456"><meta itemprop="name" content="Missing URLs"></div>`, 200) as IParsedSearch;
+        expect(parsed.images).toHaveLength(1);
+    });
+
+    it("parses full-size details without confusing recommendations for the main image", () => {
+        const details = `
+            <meta itemprop="name" content="Night &amp; Sky">
+            <meta itemprop="contentUrl" href="https://images.example/123.jpeg">
+            <meta itemprop="datePublished" content="2026-08-30">
+            <meta itemprop="keywords" content="Night, Blue Sky, Stars">
+            ${resultCard}`;
+        const parsed = source.apis.html.details!.parse(details, 200) as IParsedDetails;
+
+        expect(source.apis.html.details!.url("123", "", { baseUrl: "/", loggedIn: false })).toBe("/big.php?i=123");
+        expect(parsed).toEqual({
+            imageUrl: "https://images.example/123.jpeg",
+            createdAt: "2026-08-30",
+            tags: ["Night", "Blue Sky", "Stars"],
+        });
+    });
+
+    it("recognizes both site titles", () => {
+        expect(source.apis.html.check!.parse("<title>Wallpaper Abyss - Wallpapers</title>", 200)).toBe(true);
+        expect(source.apis.html.check!.parse("<title>Alpha Coders</title>", 200)).toBe(true);
+    });
+});

--- a/src/sites/Alpha Coders/model.ts
+++ b/src/sites/Alpha Coders/model.ts
@@ -1,0 +1,112 @@
+function metaValue(src: string, name: string): string | undefined {
+    const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const match = new RegExp(`<meta\\b(?=[^>]*\\bitemprop\\s*=\\s*["']${escapedName}["'])[^>]*\\b(?:content|href)\\s*=\\s*["']([^"']*)["'][^>]*>`, "i").exec(src);
+    return match ? Grabber.htmlDecode(match[1]) : undefined;
+}
+
+function imageFromBlock(block: string): IImage | null {
+    const fileUrl = metaValue(block, "contentUrl");
+    const pageUrl = metaValue(block, "url");
+    const previewUrl = metaValue(block, "thumbnailUrl");
+    if (!fileUrl || !pageUrl || !previewUrl) {
+        return null;
+    }
+
+    const id = pageUrl.match(/[?&]i=(\d+)/)?.[1]
+        || fileUrl.match(/\/(\d+)\.[a-z0-9]+(?:\?|$)/i)?.[1];
+    if (!id) {
+        return null;
+    }
+
+    const dimensions = block.match(/\((\d{3,5})\s*(?:x|×|&#10005;)\s*(\d{3,5})\)/i);
+    const keywords = metaValue(block, "keywords");
+    const tags = keywords
+        ? keywords.split(",").map((tag) => tag.trim()).filter((tag) => tag.length > 0)
+        : [];
+
+    const image: IImage = {
+        id,
+        page_url: pageUrl,
+        file_url: fileUrl,
+        sample_url: fileUrl,
+        preview_url: previewUrl,
+        name: metaValue(block, "name"),
+        tags,
+        created_at: metaValue(block, "datePublished"),
+        rating: "safe",
+        ext: fileUrl.match(/\.([a-z0-9]+)(?:\?|$)/i)?.[1],
+    };
+
+    if (dimensions) {
+        image.width = parseInt(dimensions[1], 10);
+        image.height = parseInt(dimensions[2], 10);
+    }
+    return image;
+}
+
+function parseImages(src: string): IImage[] {
+    return src
+        .split(/<div\s+id=["']content_/i)
+        .slice(1)
+        .map((part) => imageFromBlock(`<div id="content_${part}`))
+        .filter((image): image is IImage => image !== null);
+}
+
+export const source: ISource = {
+    name: "Wallpaper Abyss",
+    forcedTokens: [],
+    tagFormat: {
+        case: "lower",
+        wordSeparator: " ",
+    },
+    searchFormat: {
+        and: " ",
+    },
+    apis: {
+        html: {
+            name: "Regex",
+            auth: [],
+            forcedLimit: 30,
+            search: {
+                url: (query: ISearchQuery): string => {
+                    if (!query.search.trim()) {
+                        return `/featured.php?page=${query.page}`;
+                    }
+                    return `/search.php?search=${encodeURIComponent(query.search.trim())}&page=${query.page}`;
+                },
+                parse: (src: string): IParsedSearch => {
+                    const count = src.match(/\[([\d,]+)\+?\]/)?.[1];
+                    return {
+                        images: parseImages(src),
+                        imageCount: count ? parseInt(count.replace(/,/g, ""), 10) : undefined,
+                    };
+                },
+            },
+            details: {
+                url: (id: string): string => {
+                    return `/big.php?i=${id}`;
+                },
+                parse: (src: string): IParsedDetails | IError => {
+                    const imageUrl = metaValue(src, "contentUrl");
+                    if (!imageUrl) {
+                        return { error: "Could not find the full-size wallpaper URL" };
+                    }
+                    const keywords = metaValue(src, "keywords");
+                    return {
+                        imageUrl,
+                        createdAt: metaValue(src, "datePublished"),
+                        tags: keywords
+                            ? keywords.split(",").map((tag) => tag.trim()).filter((tag) => tag.length > 0)
+                            : [],
+                    };
+                },
+            },
+            check: {
+                url: (): string => "/",
+                parse: (src: string): boolean => {
+                    return /<title>[^<]*(?:Wallpaper Abyss|Alpha Coders)[^<]*<\/title>/i.test(src);
+                },
+            },
+        },
+    },
+};

--- a/src/sites/Alpha Coders/sites.txt
+++ b/src/sites/Alpha Coders/sites.txt
@@ -1,0 +1,1 @@
+wall.alphacoders.com

--- a/src/sites/Alpha Coders/supported.txt
+++ b/src/sites/Alpha Coders/supported.txt
@@ -1,0 +1,1 @@
+wall.alphacoders.com

--- a/src/sites/Alpha Coders/wall.alphacoders.com/defaults.ini
+++ b/src/sites/Alpha Coders/wall.alphacoders.com/defaults.ini
@@ -1,0 +1,14 @@
+[General]
+name=Wallpaper Abyss
+ssl=true
+
+[download]
+throttle_page=1
+throttle_details=1
+
+[sources]
+usedefault=false
+source_1=html
+source_2=
+source_3=
+source_4=


### PR DESCRIPTION
## Summary

Add first-party source support for Wallpaper Abyss at wall.alphacoders.com.

The adapter supports:

- featured browsing when the query is empty
- ordinary text search and pagination
- full-size and thumbnail URLs
- stable image IDs and page URLs
- names, comma-separated tags, publication dates, dimensions, extensions, and total result counts
- detail-page enrichment for the canonical full-size URL, tags, and publication date
- source recognition for both Wallpaper Abyss and Alpha Coders page titles

## Parsing approach

Wallpaper Abyss already publishes structured ImageObject-style meta fields inside each result card. The adapter uses those fields instead of tying parsing to presentation classes:

- contentUrl
- url
- thumbnailUrl
- name
- keywords
- datePublished

Meta attributes may appear in either order, and both content and href values are supported because the detail page uses href for its canonical full-size image.

Cards missing any required URL are skipped rather than emitted as blank results.

IDs normally come from the big.php query. A fallback extracts the numeric image ID from the canonical image filename for commercial-license cards whose page URL uses a different route.

The detail parser reads the page-level canonical metadata before recommendation cards, avoiding the common failure mode where a related image is mistaken for the selected image.

The site ID is not presented as an MD5 hash.

## Scope and defaults

- source name: Wallpaper Abyss
- default/supported host: wall.alphacoders.com
- one-second list/detail request cadence
- no authentication
- safe rating, matching this sub-site's wallpaper catalog
- no project-specific search aliases or hard-coded language synonyms

## Validation

Automated:

- 5 focused Jest tests
- TypeScript build passes
- focused TSLint passes
- tests cover URL construction, entity decoding, structured card parsing, incomplete-card rejection, detail parsing, and source recognition

Live validation on 2026-08-31 using a landscape search:

- HTTP 200
- 30 result cards parsed from 30 cards
- reported total: 16,200
- all 30 entries had ID, page URL, full URL, preview URL, width, and height
- detail request returned HTTP 200 with a full-size URL, 10 tags, and a publication date

No icon is included in this PR to avoid copying a site asset without an explicit license; Grabber supports source packages without one.