### PR TITLE
Support WallHaven resolution and color filters

### DIFF
--- a/src/sites/WallHaven/model.spec.ts
+++ b/src/sites/WallHaven/model.spec.ts
@@ -1,0 +1,43 @@
+import { makeGrabber, search } from "../test-utils";
+import { source } from "./model";
+
+describe("WallHaven", () => {
+    beforeAll(makeGrabber);
+
+    it("preserves the existing defaults for regular searches", () => {
+        expect(search(source.apis.json, "night sky", 2)).toBe(
+            "/api/v1/search?q=night%20sky&purity=111&categories=111&page=2&sorting=date_added&order=desc"
+        );
+    });
+
+    it("supports exact resolutions and minimum resolution", () => {
+        expect(search(source.apis.json, "nature resolution:1920x1080,2560:1440", 1)).toContain(
+            "resolutions=1920x1080%2C2560x1440"
+        );
+        expect(search(source.apis.json, "nature atleast:3840/2160", 1)).toContain("atleast=3840x2160");
+    });
+
+    it("uses the last resolution mode when exact and minimum filters conflict", () => {
+        const exact = search(source.apis.json, "atleast:3840x2160 res:1920x1080", 1);
+        expect(exact).toContain("resolutions=1920x1080");
+        expect(exact).not.toContain("atleast=");
+
+        const minimum = search(source.apis.json, "resolution:1920x1080 atleast:3840x2160", 1);
+        expect(minimum).toContain("atleast=3840x2160");
+        expect(minimum).not.toContain("resolutions=");
+    });
+
+    it("supports aspect ratio and color filters", () => {
+        const url = search(source.apis.json, "city ratio:16:9 color:#CC6633", 1);
+        expect(url).toContain("q=city");
+        expect(url).toContain("ratios=16x9");
+        expect(url).toContain("colors=cc6633");
+    });
+
+    it("only sends topRange for toplist searches", () => {
+        expect(search(source.apis.json, "order:toplist_desc topRange:1M", 1)).toContain(
+            "sorting=toplist&order=desc&topRange=1M"
+        );
+        expect(search(source.apis.json, "order:views topRange:1M", 1)).not.toContain("topRange=");
+    });
+});

--- a/src/sites/WallHaven/model.ts
+++ b/src/sites/WallHaven/model.ts
@@ -1,25 +1,50 @@
-function parseSearch(search: string): { query: string, purity: string, category: string, order: string, sort: string, ratios: string[] } {
+interface IWallHavenSearch {
+    query: string;
+    purity: string;
+    category: string;
+    order: string;
+    sort: string;
+    ratios: string[];
+    resolutions: string[];
+    atleast?: string;
+    colors?: string;
+    topRange?: string;
+}
+
+function parseDimensions(value: string): string[] {
+    return value
+        .split(",")
+        .map(dimension => dimension.replace(/[:/]/g, "x").toLowerCase())
+        .filter(dimension => /^\d+x\d+$/i.test(dimension));
+}
+
+function parseSearch(search: string): IWallHavenSearch {
     let query: string = "";
     let purity: string = "111";
     let category: string = "111";
     let order: string = "date_added";
     let sort: string = "desc";
     const ratios: string[] = [];
+    let resolutions: string[] = [];
+    let atleast: string | undefined;
+    let colors: string | undefined;
+    let topRange: string | undefined;
     for (const tag of search.split(" ")) {
-        if (tag.indexOf("rating:") === 0) {
-            const val = tag.substr(7);
+        const lowerTag = tag.toLowerCase();
+        if (lowerTag.indexOf("rating:") === 0) {
+            const val = lowerTag.substr(7);
             purity = val === "s" || val === "safe" ? "100" : (val === "e" || val === "explicit" ? "001" : "010");
-        } else if (tag.indexOf("-rating:") === 0) {
-            const val = tag.substr(8);
+        } else if (lowerTag.indexOf("-rating:") === 0) {
+            const val = lowerTag.substr(8);
             purity = val === "s" || val === "safe" ? "011" : (val === "e" || val === "explicit" ? "110" : "101");
-        } else if (tag.indexOf("category:") === 0) {
-            const val = tag.substr(9);
+        } else if (lowerTag.indexOf("category:") === 0) {
+            const val = lowerTag.substr(9);
             category = val === "anime" ? "010" : (val === "people" ? "001" : "100");
-        } else if (tag.indexOf("-category:") === 0) {
-            const val = tag.substr(10);
+        } else if (lowerTag.indexOf("-category:") === 0) {
+            const val = lowerTag.substr(10);
             category = val === "anime" ? "101" : (val === "people" ? "110" : "011");
-        } else if (tag.indexOf("order:") === 0) {
-            const val = tag.substr(6);
+        } else if (lowerTag.indexOf("order:") === 0) {
+            const val = lowerTag.substr(6);
             if (val.substr(-5) === "_desc") {
                 order =  val.substr(0, val.length - 5);
                 sort = "desc";
@@ -29,19 +54,43 @@ function parseSearch(search: string): { query: string, purity: string, category:
             } else {
                 order = val;
             }
-        } else if (tag.indexOf("ratio:") === 0) {
+        } else if (lowerTag.indexOf("ratio:") === 0) {
             const val = tag.substr(6);
-            ratios.push(val.replace(/[:/]/g, "x"));
+            ratios.push(...parseDimensions(val));
+        } else if (lowerTag.indexOf("resolution:") === 0 || lowerTag.indexOf("res:") === 0) {
+            const val = tag.substr(lowerTag.indexOf("resolution:") === 0 ? 11 : 4);
+            const parsed = parseDimensions(val);
+            if (parsed.length > 0) {
+                resolutions.push(...parsed);
+                atleast = undefined;
+            }
+        } else if (lowerTag.indexOf("atleast:") === 0) {
+            const parsed = parseDimensions(tag.substr(8));
+            if (parsed.length > 0) {
+                atleast = parsed[0];
+                resolutions = [];
+            }
+        } else if (lowerTag.indexOf("color:") === 0 || lowerTag.indexOf("colors:") === 0) {
+            const val = tag.substr(lowerTag.indexOf("colors:") === 0 ? 7 : 6).replace(/^#/, "");
+            if (/^[0-9a-f]{6}$/i.test(val)) {
+                colors = val.toLowerCase();
+            }
+        } else if (lowerTag.indexOf("toprange:") === 0) {
+            const val = lowerTag.substr(9);
+            const ranges: Record<string, string> = { "1d": "1d", "3d": "3d", "1w": "1w", "1m": "1M", "3m": "3M", "6m": "6M", "1y": "1y" };
+            if (ranges[val]) {
+                topRange = ranges[val];
+            }
         } else {
             query += (query ? " " : "") + tag;
         }
     }
-    return { query, purity, category, order, sort, ratios }
+    return { query, purity, category, order, sort, ratios, resolutions, atleast, colors, topRange };
 }
 
 export const source: ISource = {
     name: "WallHaven",
-    modifiers: ["rating:s", "rating:safe", "rating:q", "rating:questionable", "rating:e", "rating:explicit", "order:relevance", "order:random", "order:date_added", "order:views", "order:favorites",  "order:toplist", "order:hot", "category:general", "category:anime", "category:people"],
+    modifiers: ["rating:s", "rating:safe", "rating:q", "rating:questionable", "rating:e", "rating:explicit", "order:relevance", "order:random", "order:date_added", "order:views", "order:favorites",  "order:toplist", "order:hot", "category:general", "category:anime", "category:people", "ratio:16x9", "resolution:1920x1080", "atleast:1920x1080", "color:000000", "topRange:1M"],
     forcedTokens: ["tags"],
     auth: {
         url: {
@@ -72,6 +121,18 @@ export const source: ISource = {
                     };
                     if (search.ratios.length > 0) {
                         params["ratios"] = search.ratios.join(",");
+                    }
+                    if (search.resolutions.length > 0) {
+                        params["resolutions"] = search.resolutions.join(",");
+                    }
+                    if (search.atleast) {
+                        params["atleast"] = search.atleast;
+                    }
+                    if (search.colors) {
+                        params["colors"] = search.colors;
+                    }
+                    if (search.topRange && search.order === "toplist") {
+                        params["topRange"] = search.topRange;
                     }
                     return "/api/v1/search?" + Grabber.buildQueryParams(params);
                 },


### PR DESCRIPTION
## What and why

WallHaven's API supports several useful search filters that Grabber did not expose through its source modifiers. This adds those filters without changing the source's existing purity, category, sorting, or pagination defaults.

## New modifiers

- resolution:1920x1080 and the shorter res:1920x1080 for exact resolutions; comma-separated values are supported
- atleast:3840x2160 for a minimum resolution
- ratio:16x9 now accepts comma-separated values and also normalizes colon or slash separators
- color:cc6633 and colors:cc6633 for dominant-color filtering; a leading hash is accepted
- topRange:1M for WallHaven toplists

Exact and minimum resolution modes are mutually exclusive in WallHaven. If both are entered, the last one wins, so Grabber never sends an ambiguous request. topRange is only sent when sorting is toplist, as required by the API. Modifier recognition is case-insensitive, while ordinary search text is kept intact.

Official parameter reference: https://wallhaven.cc/help/api

## Validation

- Added five focused Jest tests covering existing defaults, resolution normalization, conflict handling, color and ratio filters, and toplist ranges
- TypeScript build passes
- Targeted TSLint passes
- Live API checks returned 24 filtered results for both minimum-resolution toplist and exact 1920x1080 color-filtered searches